### PR TITLE
Fixing a bug in jpi plot_multierror

### DIFF
--- a/picaso/justplotit.py
+++ b/picaso/justplotit.py
@@ -146,10 +146,11 @@ def plot_multierror(x,y,plot, dx_up=0, dx_low=0, dy_up=0, dy_low=0,
     error_kwargs : dict 
         formatting for error bar lines
     """
-    #first turn everything into lists 
-    for i in [dx_up, dx_low, dy_up, dy_low]:
-        if isinstance(i, (float, int)):
-            i = [i]*len(x)
+    #first turn everything into lists
+    (dx_up, dx_low, dy_up, dy_low) = [[i]*len(x)
+                                      if isinstance(i, (float, int)) else i
+                                      for i in [dx_up, dx_low, dy_up, dy_low]]
+
 
     #first x error
     y_err = []
@@ -160,7 +161,7 @@ def plot_multierror(x,y,plot, dx_up=0, dx_low=0, dy_up=0, dy_low=0,
 
     plot.multi_line(x_err, y_err, **error_kwargs)
 
-    #first y error
+    #then y error
     y_err = []
     x_err = []
     for px, py, y_up, y_low in zip(x, y, dy_up, dy_low):


### PR DESCRIPTION
Using a non-list value for the dx_up, dx_low, dy_up or dy_low params (including the default values of 0) resulted in an error because the initial conversion of ints/floats in the function to lists wasn't working as expected.

The assignment of the new list objects in the loop rebinds the i variable to the new value, as opposed to modifying the element of the list. Apparently modification of what the loop variable is pointing to is only allowed for mutable types, which ints aren't. 

This meant that the call to .zip() could then have non-list params, which breaks with `TypeError: 'int' object is not iterable`

https://stackoverflow.com/questions/9414399/modifying-a-list-iterator-in-python-not-allowed