### PR TITLE
Fixing a bug in jpi.spectrum() 

### DIFF
--- a/picaso/justplotit.py
+++ b/picaso/justplotit.py
@@ -326,7 +326,7 @@ def spectrum(xarray, yarray,legend=None,wno_to_micron=True, palette = Colorblind
         x_axis_label = 'Wavenumber [cm-1]'
         def conv(x):
             return x
-
+    if isinstance(legend, str): legend=[legend]
     kwargs['plot_height'] = kwargs.get('plot_height',345)
     kwargs['plot_width'] = kwargs.get('plot_width',1000)
     kwargs['y_axis_label'] = kwargs.get('y_axis_label','Spectrum')

--- a/picaso/justplotit.py
+++ b/picaso/justplotit.py
@@ -354,7 +354,7 @@ def spectrum(xarray, yarray,legend=None,wno_to_micron=True, palette = Colorblind
             else:
                 f = fig.line(conv(xarray), yarray, color=palette[i], line_width=3,
                                 muted_color=palette[np.mod(i, len(palette))], muted_alpha=muted_alpha)
-                legend_it.append((l, [f]))
+                legend_it.append((legend[i], [f]))
         i = i+1
 
     if not isinstance(legend,type(None)):


### PR DESCRIPTION
If you hit line 357 in justplotit.py, you got a `"local variable 'l' referenced before assignment"` error. Updated to instead access the current index in the given legend list.

This is only in the case where you supply your own list of legends and a single xarray.