### PR TITLE
Update atmsetup.py

### DIFF
--- a/picaso/atmsetup.py
+++ b/picaso/atmsetup.py
@@ -498,10 +498,12 @@ class ATMSETUP():
             self.layer['cloud'] = {'opd': opd}
             #cloud assymetry parameter
             g0 = np.reshape(cld_input['g0'].values, (self.c.nlayer,self.c.input_npts_wave))
+            g0 = g0.astype(np.float64)
             if regrid: g0 = regrid_cld(g0, self.input_wno, wno)
             self.layer['cloud']['g0'] = g0
             #cloud single scattering albedo 
             w0 = np.reshape(cld_input['w0'].values, (self.c.nlayer,self.c.input_npts_wave))
+            w0 = w0.astype(np.float64)
             if regrid: w0 = regrid_cld(w0, self.input_wno, wno)
             self.layer['cloud']['w0'] = w0  
 

--- a/picaso/atmsetup.py
+++ b/picaso/atmsetup.py
@@ -493,6 +493,7 @@ class ATMSETUP():
             #then reshape and regrid inputs to be a nice matrix that is nlayer by nwave
             #total extinction optical depth 
             opd = np.reshape(cld_input['opd'].values, (self.c.nlayer,self.c.input_npts_wave))
+            opd = opd.astype(np.float64)
             if regrid: opd = regrid_cld(opd, self.input_wno, wno)
             self.layer['cloud'] = {'opd': opd}
             #cloud assymetry parameter


### PR DESCRIPTION
Solve the following issue

---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Input In [82], in <cell line: 9>()
     20 cld_output[f'fsed{ifsed}_logkzz{np.log10(ikzz)}'] = virga_w39.virga(gas_condensates,
     21                                                                 virga_dir,
     22                                                                 fsed=fsed,
     23                                                                 mh=metallicity,
     24          mmw = mean_molecular_weight,full_output=True, verbose=False)
     25 #new spectrum
---> 26 df_spec = virga_w39.spectrum(opa, calculation='transmission',full_output=True)
     27 virga_models[f'fsed{ifsed}_logkzz{np.log10(ikzz)}']=df_spec
     28 print(f'Chi-Sq of fsed{ifsed},logkzz{np.log10(ikzz)}:' ,chisqr(df_spec))

File ~/.local/lib/python3.10/site-packages/picaso/justdoit.py:3604, in inputs.spectrum(self, opacityclass, calculation, dimension, full_output, plot_opacity, as_dict)
   3600     self.inputs['surface_reflect'] = 0 
   3601     self.inputs['hard_surface'] = 0 
-> 3604 return picaso(self, opacityclass,dimension=dimension,calculation=calculation,
   3605     full_output=full_output, plot_opacity=plot_opacity, as_dict=as_dict)

File ~/.local/lib/python3.10/site-packages/picaso/justdoit.py:195, in picaso(bundle, opacityclass, dimension, calculation, full_output, plot_opacity, as_dict)
    191 atm.get_needed_continuum(opacityclass.rayleigh_molecules,
    192                          opacityclass.avail_continuum)
    194 #get cloud properties, if there are any and put it on current grid 
--> 195 atm.get_clouds(wno)
    197 #Make sure that all molecules are in opacityclass. If not, remove them and add warning
    198 no_opacities = [i for i in atm.molecules if i not in opacityclass.molecules]

File ~/.local/lib/python3.10/site-packages/picaso/atmsetup.py:496, in ATMSETUP.get_clouds(self, wno)
    493 #then reshape and regrid inputs to be a nice matrix that is nlayer by nwave
    494 #total extinction optical depth 
    495 opd = np.reshape(cld_input['opd'].values, (self.c.nlayer,self.c.input_npts_wave))
--> 496 if regrid: opd = regrid_cld(opd, self.input_wno, wno)
    497 self.layer['cloud'] = {'opd': opd}
    498 #cloud assymetry parameter

File ~/.local/lib/python3.10/site-packages/picaso/wavelength.py:68, in regrid(matrix, old_wno, new_wno)
     66 new = np.zeros((matrix.shape[0],len(new_wno)))
     67 for i in range(matrix.shape[0]): 
---> 68 	new[i, :] = np.interp(new_wno, old_wno, matrix[i,:])
     69 	#f = sci.interp1d(old_wno, matrix[i,:],kind='cubic')
     70 	#new[i, :] = f(new_wno)
     71 return new

File <__array_function__ internals>:200, in interp(*args, **kwargs)

File ~/.local/lib/python3.10/site-packages/numpy/lib/function_base.py:1595, in interp(x, xp, fp, left, right, period)
   1592     xp = np.concatenate((xp[-1:]-period, xp, xp[0:1]+period))
   1593     fp = np.concatenate((fp[-1:], fp, fp[0:1]))
-> 1595 return interp_func(x, xp, fp, left, right)

TypeError: Cannot cast array data from dtype('O') to dtype('float64') according to the rule 'safe'