### PR TITLE
Arraysingular

### DIFF
--- a/docs/notebooks/climate/12b_Exoplanet.ipynb
+++ b/docs/notebooks/climate/12b_Exoplanet.ipynb
@@ -83,7 +83,7 @@
     "$T_{int}$, the intrinsic effective temperature, that describes the flux from the planet’s\n",
     "interior. These temperatures are related by:\n",
     "\n",
-    "> $T_{eff} =  T_{int} + T_{eq}$\n",
+    "> $T_{eff}^4 =  T_{int}^4 + T_{eq}^4$\n",
     "\n",
     "> We then recover our limiting cases: if a planet is self-luminous (like a young giant\n",
     "planet) and far from its parent star, $T_{eff} \\approx  T_{int}$; for most rocky planets, or any\n",

--- a/docs/notebooks/climate/12b_Exoplanet.ipynb
+++ b/docs/notebooks/climate/12b_Exoplanet.ipynb
@@ -301,6 +301,24 @@
    "source": [
     "brightness_temp, figure= jpi.brightness_temperature(out['spectrum_output'])"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Check Adiabat \n",
+    "\n",
+    "This plot and datareturn is helpful to check that there have been no issues with where the code has found the location of the convective zone(s). See below, dTdP never exceeds the adiabat.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adiabat, dtdp, pressure = jpi.pt_adiabat(out, cl_run)"
+   ]
   }
  ],
  "metadata": {

--- a/docs/notebooks/climate/12b_Exoplanet.ipynb
+++ b/docs/notebooks/climate/12b_Exoplanet.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "1. [Download](https://zenodo.org/record/5590989#.Yzy2YOzMI8a) 196 Correlated-K Tables from Roxana Lupu to be used by the climate code for opacity (if you completed the brown dwarf tutorial you should already have this)\n",
     "\n",
-    "**Note**: the two files above are dependent on metallicity and C/O. For this tutorial we will stick to solar M/H and solar C/O, but note that you can change that in the future. "
+    "**Note**: the two files above are dependent on metallicity and C/O. "
    ]
   },
   {
@@ -45,8 +45,8 @@
    "outputs": [],
    "source": [
     "#1 ck tables from roxana\n",
-    "mh = '+100'#'+1.0' #log metallicity\n",
-    "CtoO = '100'#'1.0' # CtoO ratio\n",
+    "mh = '+100'#'+1.0' #log metallicity, 10xSolar\n",
+    "CtoO = '100'#'1.0' # CtoO ratio, Solar C/O\n",
     "\n",
     "ck_db = f'/data/kcoeff_2020/sonora_2020_feh{mh}_co_{CtoO}/sonora_2020_feh{mh}_co_{CtoO}.data.196'"
    ]
@@ -319,7 +319,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.11.5"
   },
   "toc": {
    "base_numbering": 1,

--- a/picaso/atmsetup.py
+++ b/picaso/atmsetup.py
@@ -616,8 +616,12 @@ class ATMSETUP():
         df['level']['pressure'] = self.level['pressure']/ self.c.pconv #bars
         df['level']['temperature'] = self.level['temperature']
         
+        #return the level fluxes if the user requests that particular output
         if self.get_lvl_flux:
-            df['level'] = self.lvl_output
+            if not isinstance(getattr(self,'lvl_output_thermal',None), type(None)):
+                df['level']['thermal_fluxes'] = self.lvl_output_thermal
+            if not isinstance(getattr(self,'lvl_output_reflected',None), type(None)):    
+                df['level']['reflected_fluxes'] = self.lvl_output_reflected
 
         df['latitude'] = self.latitude
         df['longitude'] = self.longitude

--- a/picaso/atmsetup.py
+++ b/picaso/atmsetup.py
@@ -615,6 +615,9 @@ class ATMSETUP():
         df['level'] = {}
         df['level']['pressure'] = self.level['pressure']/ self.c.pconv #bars
         df['level']['temperature'] = self.level['temperature']
+        
+        if self.get_lvl_flux:
+            df['level'] = self.lvl_output
 
         df['latitude'] = self.latitude
         df['longitude'] = self.longitude

--- a/picaso/climate.py
+++ b/picaso/climate.py
@@ -409,7 +409,7 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
 
     # here are other  convergence and tolerance criterias
 
-    step_max_tolerance = 0.03e0 # scaled maximum step size in line searches
+    step_max = 0.01e0 # scaled maximum step size in line searches
     alf = 1.e-4    # ? 
     alam2 = 0.0   # ? 
     tolmin=1.e-5   # ?
@@ -551,7 +551,7 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
             
         
         # define maximum T step size
-        step_max = step_max_tolerance*max(sqrt(sum_1),n_total*1.0)
+        step_max *= max(sqrt(sum_1),n_total*1.0)#step_max_tolerance*
         print('maximum scaled step size',step_max, n_total, sum_1)
         no =n_top_r
         
@@ -896,9 +896,9 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
                 nao+= n_bot_a - n_strt_a
                         
             f= 0.5*sum
-            print('cond1:alam.lt.alamin',alam, alamin)
-            print('cond2:f.le.CCC',f,f_old + alf*alam*slope)
-            print('f,fold,alf,alam,slope',f,f_old,alf,alam,slope)
+            #print('cond1:alam.lt.alamin',alam, alamin)
+            #print('cond2:f.le.CCC',f,f_old + alf*alam*slope)
+            #print('f,fold,alf,alam,slope',f,f_old,alf,alam,slope)
             #First check: Is T too small to continue? 
             if alam < alamin :
                 #print(alam, alamin)

--- a/picaso/climate.py
+++ b/picaso/climate.py
@@ -1213,7 +1213,7 @@ def get_fluxes( pressure, temperature, dwni,  bb , y2, tp, tmin, tmax ,DTAU, TAU
             
             #"""<<<<<<< NEWCLIMA
             hard_surface = 0 
-            _,out_therm_fluxes = get_thermal_1d_newclima(nlevel, wno,nwno,ng,nt,temperature,
+            _,out_therm_fluxes = get_thermal_1d(nlevel, wno,nwno,ng,nt,temperature,
                                             DTAU_OG[:,:,ig], W0_no_raman[:,:,ig], COSB_OG[:,:,ig], 
                                             pressure,ubar1,
                                             surf_reflect, hard_surface, dwni, calc_type=1)

--- a/picaso/climate.py
+++ b/picaso/climate.py
@@ -2,8 +2,8 @@ import numpy as np
 import warnings
 from numba import jit, vectorize
 from numpy import exp, zeros, where, sqrt, cumsum , pi, outer, sinh, cosh, min, dot, array,log,log10
-from .fluxes import get_reflected_1d, get_thermal_1d_gfluxi,get_thermal_1d,get_reflected_1d_gfluxv
-from .fluxes import get_thermal_1d_newclima
+from .fluxes import get_reflected_1d,get_thermal_1d,get_reflected_1d_gfluxv
+#from .fluxes import get_thermal_1d_newclima, get_thermal_1d_gfluxi #deprecated
 from .atmsetup import ATMSETUP
 from .optics import compute_opacity
 from .disco import compress_thermal

--- a/picaso/climate.py
+++ b/picaso/climate.py
@@ -2,8 +2,8 @@ import numpy as np
 import warnings
 from numba import jit, vectorize
 from numpy import exp, zeros, where, sqrt, cumsum , pi, outer, sinh, cosh, min, dot, array,log,log10
-from .fluxes import get_reflected_1d,get_thermal_1d,get_reflected_1d_gfluxv, get_reflected_1d_newclima
-#from .fluxes import get_thermal_1d_newclima, get_thermal_1d_gfluxi #deprecated
+from .fluxes import get_reflected_1d,get_thermal_1d,get_reflected_1d_newclima
+#from .fluxes import get_thermal_1d_newclima, get_thermal_1d_gfluxi,get_reflected_1d_gfluxv #deprecated
 from .atmsetup import ATMSETUP
 from .optics import compute_opacity
 from .disco import compress_thermal
@@ -333,7 +333,7 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
             grad, cp, tidal, tmin,tmax, dwni , bb , y2, tp, DTAU, TAU, W0, COSB, 
             ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, ubar0,ubar1,
             cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,
-            constant_back,constant_forward, tridiagonal , wno,nwno,ng,nt,gweight,tweight, ngauss, gauss_wts, save_profile, all_profiles):
+            constant_back,constant_forward,  wno,nwno,ng,nt,gweight,tweight, ngauss, gauss_wts, save_profile, all_profiles):
     """
     Module to iterate on the level TP profile to make the Net Flux as close to 0.
     Opacities/chemistry are not updated while iterating in this module.
@@ -422,7 +422,7 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
     else:compute_reflected=True
     flux_net_v_layer_full, flux_net_v_full, flux_plus_v_full, flux_minus_v_full , flux_net_ir_layer_full, flux_net_ir_full, flux_plus_ir_full, flux_minus_ir_full = get_fluxes(pressure, temp, dwni, bb , y2, tp, tmin, tmax, DTAU, TAU, W0, 
             COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, 
-            ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , 
+            ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, 
             wno,nwno,ng,nt, gweight,tweight, nlevel, ngauss, gauss_wts,compute_reflected, True)#True for reflected, True for thermal
 
     # extract visible fluxes
@@ -625,7 +625,7 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
 
                 flux_net_v_layer_full, flux_net_v_full, flux_plus_v_full, flux_minus_v_full , flux_net_ir_layer_full, flux_net_ir_full, flux_plus_ir_full, flux_minus_ir_full = get_fluxes(pressure, temp, dwni, bb , y2, tp, tmin, tmax, DTAU, TAU, W0, 
             COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, 
-            ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , 
+            ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, 
             wno,nwno,ng,nt,gweight,tweight, nlevel, ngauss, gauss_wts, False, True) #false for reflected, True for thermal
 
 
@@ -840,7 +840,7 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
             # re calculate thermal flux
             flux_net_v_layer_full, flux_net_v_full, flux_plus_v_full, flux_minus_v_full , flux_net_ir_layer_full, flux_net_ir_full, flux_plus_ir_full, flux_minus_ir_full = get_fluxes(pressure, temp, dwni, bb , y2, tp, tmin, tmax, DTAU, TAU, W0, 
             COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, 
-            ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , 
+            ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward,
             wno,nwno,ng,nt,gweight,tweight, nlevel, ngauss, gauss_wts, False, True) #false reflected, True thermal
 
 
@@ -1073,7 +1073,7 @@ def growdown(nlv,nstr, ngrow) :
 @jit(nopython=True, cache=True)
 def get_fluxes( pressure, temperature, dwni,  bb , y2, tp, tmin, tmax ,DTAU, TAU, W0, 
             COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, 
-            ubar0,ubar1,cos_theta, F0PI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , 
+            ubar0,ubar1,cos_theta, F0PI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward,
             wno,nwno,ng,nt,gweight,tweight, nlevel, ngauss, gauss_wts,reflected, thermal):
     """
     Program to run RT for climate calculations. Runs the thermal and reflected module.
@@ -1301,7 +1301,6 @@ def calculate_atm(bundle, opacityclass):
     raman_approx =inputs['approx']['rt_params']['common']['raman']
     method = inputs['approx']['rt_method']
     stream = inputs['approx']['rt_params']['common']['stream']
-    tridiagonal = 0 
 
     #parameters needed for the two term hg phase function. 
     #Defaults are set in config.json
@@ -1401,7 +1400,7 @@ def calculate_atm(bundle, opacityclass):
     #mmw = np.mean(atm.layer['mmw'])
     mmw = atm.layer['mmw']
     
-    return DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , atm.surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw,gweight,tweight
+    return DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , atm.surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw,gweight,tweight
 
 
 def calculate_atm_deq(bundle, opacityclass,on_fly=False,gases_fly=None):
@@ -1425,7 +1424,6 @@ def calculate_atm_deq(bundle, opacityclass,on_fly=False,gases_fly=None):
     raman_approx =inputs['approx']['rt_params']['common']['raman']
     method = inputs['approx']['rt_method']
     stream = inputs['approx']['rt_params']['common']['stream']
-    tridiagonal = 0 
 
     #parameters needed for the two term hg phase function. 
     #Defaults are set in config.json
@@ -1522,4 +1520,4 @@ def calculate_atm_deq(bundle, opacityclass,on_fly=False,gases_fly=None):
     #mmw = np.mean(atm.layer['mmw'])
     mmw = atm.level['mmw']
     
-    return DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , atm.surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw
+    return DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , atm.surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw

--- a/picaso/climate.py
+++ b/picaso/climate.py
@@ -2,7 +2,7 @@ import numpy as np
 import warnings
 from numba import jit, vectorize
 from numpy import exp, zeros, where, sqrt, cumsum , pi, outer, sinh, cosh, min, dot, array,log,log10
-from .fluxes import get_reflected_1d,get_thermal_1d,get_reflected_1d_newclima
+from .fluxes import get_reflected_1d,get_thermal_1d
 #from .fluxes import get_thermal_1d_newclima, get_thermal_1d_gfluxi,get_reflected_1d_gfluxv #deprecated
 from .atmsetup import ATMSETUP
 from .optics import compute_opacity

--- a/picaso/climate.py
+++ b/picaso/climate.py
@@ -1195,7 +1195,7 @@ def climate( pressure, temperature, dwni,  bb , y2, tp, tmin, tmax ,DTAU, TAU, W
             calc_type=1 # this line might change depending on Natasha's new function
             
             #for iubar,weights in zip(ugauss_angles,ugauss_weights):
-            flux_minus_all_i, flux_plus_all_i, flux_minus_midpt_all_i, flux_plus_midpt_all_i=get_thermal_1d_gfluxi(nlevel,wno,nwno,ng,nt,temperature,DTAU_OG[:,:,ig], W0_no_raman[:,:,ig], COSB_OG[:,:,ig], pressure,ubar1,surf_reflect, ugauss_angles,ugauss_weights, tridiagonal,calc_type, bb , y2, tp, tmin, tmax)
+            flux_minus_all_i, flux_plus_all_i, flux_minus_midpt_all_i, flux_plus_midpt_all_i=get_thermal_1d_gfluxi(nlevel,wno,nwno,ng,nt,temperature,DTAU_OG[:,:,ig], W0_no_raman[:,:,ig], COSB_OG[:,:,ig], pressure,ubar1,surf_reflect, ugauss_angles,ugauss_weights, tridiagonal,calc_type, dwni)#bb , y2, tp, tmin, tmax)
 
             flux_plus += flux_plus_all_i*gauss_wts[ig]#*weights
             flux_minus += flux_minus_all_i*gauss_wts[ig]#*weights

--- a/picaso/climate.py
+++ b/picaso/climate.py
@@ -1449,6 +1449,12 @@ def calculate_atm_deq(bundle, opacityclass,on_fly=False,gases_fly=None):
     #get geometry
     geom = inputs['disco']
 
+    ng, nt = geom['num_gangle'], geom['num_tangle']#1,1 #
+    gangle,gweight,tangle,tweight = geom['gangle'], geom['gweight'],geom['tangle'], geom['tweight']
+    lat, lon = geom['latitude'], geom['longitude']
+    cos_theta = geom['cos_theta']
+    ubar0, ubar1 = geom['ubar0'], geom['ubar1']
+    """
     ng, nt = 1,1 #geom['num_gangle'], geom['num_tangle']
     gangle,gweight,tangle,tweight = geom['gangle'], geom['gweight'],geom['tangle'], geom['tweight']
     lat, lon = geom['latitude'], geom['longitude']
@@ -1459,6 +1465,7 @@ def calculate_atm_deq(bundle, opacityclass,on_fly=False,gases_fly=None):
     ubar0 += 0.5
     ubar1 += 0.5
     #print(ubar0,ubar1)
+    """
 
     #set star parameters
     radius_star = inputs['star']['radius']
@@ -1520,4 +1527,4 @@ def calculate_atm_deq(bundle, opacityclass,on_fly=False,gases_fly=None):
     #mmw = np.mean(atm.layer['mmw'])
     mmw = atm.level['mmw']
     
-    return DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , atm.surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw
+    return DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , atm.surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw,gweight,tweight

--- a/picaso/climate.py
+++ b/picaso/climate.py
@@ -412,7 +412,7 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
     tolx = tolf    # tolerance in fractional T change we are aiming for
 
     #both reflected and thermal
-    flux_net_v_layer_full, flux_net_v_full, flux_plus_v_full, flux_minus_v_full , flux_net_ir_layer_full, flux_net_ir_full, flux_plus_ir_full, flux_minus_ir_full = climate(pressure, temp, dwni, bb , y2, tp, tmin, tmax, DTAU, TAU, W0, 
+    flux_net_v_layer_full, flux_net_v_full, flux_plus_v_full, flux_minus_v_full , flux_net_ir_layer_full, flux_net_ir_full, flux_plus_ir_full, flux_minus_ir_full = get_fluxes(pressure, temp, dwni, bb , y2, tp, tmin, tmax, DTAU, TAU, W0, 
             COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, 
             ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , 
             wno,nwno,ng,nt, nlevel, ngauss, gauss_wts,True, True)#True for reflected, True for thermal
@@ -611,7 +611,7 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
                 # temperature has been perturbed
                 # now recalculate the IR fluxes, so call picaso with only thermal
 
-                flux_net_v_layer_full, flux_net_v_full, flux_plus_v_full, flux_minus_v_full , flux_net_ir_layer_full, flux_net_ir_full, flux_plus_ir_full, flux_minus_ir_full = climate(pressure, temp, dwni, bb , y2, tp, tmin, tmax, DTAU, TAU, W0, 
+                flux_net_v_layer_full, flux_net_v_full, flux_plus_v_full, flux_minus_v_full , flux_net_ir_layer_full, flux_net_ir_full, flux_plus_ir_full, flux_minus_ir_full = get_fluxes(pressure, temp, dwni, bb , y2, tp, tmin, tmax, DTAU, TAU, W0, 
             COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, 
             ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , 
             wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, False, True) #false for reflected, True for thermal
@@ -820,7 +820,7 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
                     temp[j1] = tmax- 0.1
             
             # re calculate thermal flux
-            flux_net_v_layer_full, flux_net_v_full, flux_plus_v_full, flux_minus_v_full , flux_net_ir_layer_full, flux_net_ir_full, flux_plus_ir_full, flux_minus_ir_full = climate(pressure, temp, dwni, bb , y2, tp, tmin, tmax, DTAU, TAU, W0, 
+            flux_net_v_layer_full, flux_net_v_full, flux_plus_v_full, flux_minus_v_full , flux_net_ir_layer_full, flux_net_ir_full, flux_plus_ir_full, flux_minus_ir_full = get_fluxes(pressure, temp, dwni, bb , y2, tp, tmin, tmax, DTAU, TAU, W0, 
             COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, 
             ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , 
             wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, False, True) #false reflected, True thermal
@@ -1046,7 +1046,7 @@ def growdown(nlv,nstr, ngrow) :
     return nstr
 
 @jit(nopython=True, cache=True)
-def climate( pressure, temperature, dwni,  bb , y2, tp, tmin, tmax ,DTAU, TAU, W0, 
+def get_fluxes( pressure, temperature, dwni,  bb , y2, tp, tmin, tmax ,DTAU, TAU, W0, 
             COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, 
             ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , 
             wno,nwno,ng,nt, nlevel, ngauss, gauss_wts,reflected, thermal):
@@ -1228,6 +1228,10 @@ def climate( pressure, temperature, dwni,  bb , y2, tp, tmin, tmax ,DTAU, TAU, W
         #if full output is requested add in flux at top for 3d plots
     
     return flux_net_v_layer, flux_net_v, flux_plus_v, flux_minus_v , flux_net_ir_layer, flux_net_ir, flux_plus_ir, flux_minus_ir
+
+#soon I will deprecate the function name "climate" as it is really confusing with what it 
+#actually does, which is just run the RT to get fluxes
+climate = get_fluxes
 
 def calculate_atm(bundle, opacityclass):
 

--- a/picaso/climate.py
+++ b/picaso/climate.py
@@ -3,6 +3,7 @@ import warnings
 from numba import jit, vectorize
 from numpy import exp, zeros, where, sqrt, cumsum , pi, outer, sinh, cosh, min, dot, array,log,log10
 from .fluxes import get_reflected_1d, get_thermal_1d_gfluxi,get_thermal_1d,get_reflected_1d_gfluxv
+from .fluxes import get_thermal_1d_newclima
 from .atmsetup import ATMSETUP
 from .optics import compute_opacity
 from .disco import compress_thermal
@@ -166,6 +167,10 @@ def locate(array,value):
     
     return jl
 
+
+
+
+
 @jit(nopython=True, cache=True)
 def mat_sol(a, nlevel, nstrat, dflux):
     """
@@ -322,13 +327,13 @@ def lu_backsubs(a, n, ntot, indx, b):
     return b
 
 # @logger.catch # Add this to track errors
-@jit(nopython=True, cache=True)
+#@jit(nopython=True, cache=True)
 def t_start(nofczns,nstr,it_max,conv,x_max_mult, 
             rfaci, rfacv, nlevel, temp, pressure, p_table, t_table, 
             grad, cp, tidal, tmin,tmax, dwni , bb , y2, tp, DTAU, TAU, W0, COSB, 
             ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, ubar0,ubar1,
             cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,
-            constant_back,constant_forward, tridiagonal , wno,nwno,ng,nt, ngauss, gauss_wts, save_profile, all_profiles):
+            constant_back,constant_forward, tridiagonal , wno,nwno,ng,nt,gweight,tweight, ngauss, gauss_wts, save_profile, all_profiles):
     """
     Module to iterate on the level TP profile to make the Net Flux as close to 0.
     Opacities/chemistry are not updated while iterating in this module.
@@ -404,18 +409,21 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
 
     # here are other  convergence and tolerance criterias
 
-    step_max = 0.01e0 # scaled maximum step size in line searches
+    step_max_tolerance = 0.03e0 # scaled maximum step size in line searches
     alf = 1.e-4    # ? 
     alam2 = 0.0   # ? 
     tolmin=1.e-5   # ?
     tolf = 5e-3    # tolerance in fractional Flux we are aiming for
-    tolx = tolf    # tolerance in fractional T change we are aiming for
+    tolx = 5e-3    # tolerance in fractional T change we are aiming for
 
     #both reflected and thermal
+    #neb this double true in the first call to reflected light needs to be changed
+    if rfacv==0:compute_reflected=False
+    else:compute_reflected=True
     flux_net_v_layer_full, flux_net_v_full, flux_plus_v_full, flux_minus_v_full , flux_net_ir_layer_full, flux_net_ir_full, flux_plus_ir_full, flux_minus_ir_full = get_fluxes(pressure, temp, dwni, bb , y2, tp, tmin, tmax, DTAU, TAU, W0, 
             COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, 
             ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , 
-            wno,nwno,ng,nt, nlevel, ngauss, gauss_wts,True, True)#True for reflected, True for thermal
+            wno,nwno,ng,nt, gweight,tweight, nlevel, ngauss, gauss_wts,compute_reflected, True)#True for reflected, True for thermal
 
     # extract visible fluxes
     flux_net_v_layer = flux_net_v_layer_full[0,0,:]  #fmnetv
@@ -424,7 +432,6 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
     flux_minus_v = flux_minus_v_full[0,0,:,:]
 
     # extract ir fluxes
-
     flux_net_ir_layer = flux_net_ir_layer_full[:] #fmneti
     flux_net_ir = flux_net_ir_full[:]     #fneti
     flux_plus_ir = flux_plus_ir_full[:,:]  
@@ -440,7 +447,7 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
     p=np.zeros(shape=(nlevel)) #p
     g=np.zeros(shape=(nlevel))
     
-    #--SM-- jacobian?
+    # jacobian of zeros
     A= np.zeros(shape=(nlevel,nlevel)) 
     
 
@@ -452,6 +459,10 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
         flux_net = rfaci* flux_net_ir + rfacv* flux_net_v +tidal #fnet
         flux_net_midpt = rfaci* flux_net_ir_layer + rfacv* flux_net_v_layer +tidal #fmnet
         
+        #print('flux_net_midpt',flux_net_midpt)
+
+        #raise Exception ('stop in tstart')
+
         beta= temp.copy() # beta vector
         
        
@@ -540,8 +551,8 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
             
         
         # define maximum T step size
-        step_max *= max(sqrt(sum_1),n_total*1.0)
-
+        step_max = step_max_tolerance*max(sqrt(sum_1),n_total*1.0)
+        print('maximum scaled step size',step_max, n_total, sum_1)
         no =n_top_r
         
         i_count= 1 #icount
@@ -572,6 +583,7 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
 
                 i_count += 1
 
+                #eps is just a tolerance value currently fixed at 1e-4
                 del_t = max(eps * temp_old[jm], 3.0) # perturbation
 
                 beta[jm] += del_t # perturb
@@ -614,7 +626,7 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
                 flux_net_v_layer_full, flux_net_v_full, flux_plus_v_full, flux_minus_v_full , flux_net_ir_layer_full, flux_net_ir_full, flux_plus_ir_full, flux_minus_ir_full = get_fluxes(pressure, temp, dwni, bb , y2, tp, tmin, tmax, DTAU, TAU, W0, 
             COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, 
             ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , 
-            wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, False, True) #false for reflected, True for thermal
+            wno,nwno,ng,nt,gweight,tweight, nlevel, ngauss, gauss_wts, False, True) #false for reflected, True for thermal
 
 
                 # extract ir fluxes
@@ -701,6 +713,11 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
         
         f_old = f #fold
         
+        #print('f_vec[0],f_vec[-1],min,max:f_vec', 
+        #    f_vec[0],f_vec[-1],min(f_vec),max(f_vec))
+        #print(f_vec)
+        #raise Exception ("stop")
+
         A, p = mat_sol(A, nlevel, n_total, p)
         
         #print(p)
@@ -746,10 +763,11 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
         alam = 1.0
         
         f2= f #################### to avoid call before assignment and run using numba
-        #print(alamin)
-
-        ## stick a while loop here maybe for the weird fortran goto 1
-        # you have in tstart.
+        #     Convergence test:  Find magnitude of correction by comparing
+        #        temperature steps to a appropriate scale SCALT.  If average
+        #        correction ERR is large, use only a fraction of the step.
+        #        When ERR is less than CONV, routine has converged.
+        
         flag_converge = 0
         # instead of the goto statement here
         #ct_num = 0
@@ -823,7 +841,7 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
             flux_net_v_layer_full, flux_net_v_full, flux_plus_v_full, flux_minus_v_full , flux_net_ir_layer_full, flux_net_ir_full, flux_plus_ir_full, flux_minus_ir_full = get_fluxes(pressure, temp, dwni, bb , y2, tp, tmin, tmax, DTAU, TAU, W0, 
             COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, 
             ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , 
-            wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, False, True) #false reflected, True thermal
+            wno,nwno,ng,nt,gweight,tweight, nlevel, ngauss, gauss_wts, False, True) #false reflected, True thermal
 
 
            
@@ -878,29 +896,33 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
                 nao+= n_bot_a - n_strt_a
                         
             f= 0.5*sum
-            # check_convergence is fortran from line indexed 9995 till next line of 19
+            print('cond1:alam.lt.alamin',alam, alamin)
+            print('cond2:f.le.CCC',f,f_old + alf*alam*slope)
+            print('f,fold,alf,alam,slope',f,f_old,alf,alam,slope)
+            #First check: Is T too small to continue? 
             if alam < alamin :
                 #print(alam, alamin)
                 check = True
-                #print(' CONVERGED ON SMALL T STEP')
+                print(' CONVERGED ON SMALL T STEP alam, alamin', alam, alamin)
                 #print("1st if")
                 #print(alam, alamin)
                 flag_converge, check = check_convergence(f_vec, n_total, tolf, check, f, dflux, tolmin, temp, temp_old, g , tolx)
  
-            
+            #Second check: Has the net flux decreased enough that we are happy in the line search
+            #If so you can proceed
             elif f <= f_old + alf*alam*slope :
                 #print("2nd if")
                 
                 
-                #print ('Exit with decreased f')
+                print ('Exit with decreased f')
                 flag_converge, check = check_convergence(f_vec, n_total, tolf, check, f, dflux, tolmin, temp, temp_old, g , tolx)
 
-                
+            #Else: Let's back track     
             else:
                 
                 # we backtrack
                 #print("3rd if")
-                #print(' Now backtracking, f, fold, alf, alam, slope', f, f_old, alf, alam, slope)
+                print(' Now backtracking, f, fold, alf, alam, slope', f, f_old, alf, alam, slope)
                 if alam == 1.0:
                     
                     tmplam= -slope/ (2*(f-f_old-slope))
@@ -942,7 +964,9 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
                 
                 flag_converge = 1 # to avoid getting stuck here unnecesarily.
                 temp = temp_old.copy() +0.5
-                print("Got stuck-- so escaping the while loop in tstart")
+                print("Got stuck with temp NaN -- so escaping the while loop in tstart")
+        
+
         print("Iteration number ", its,", min , max temp ", min(temp),max(temp), ", flux balance ", flux_net[0]/abs(tidal[0]))
         #print(f, f_old, tolf, np.max((temp-temp_old)/temp_old), tolx)
         if save_profile == 1:
@@ -984,6 +1008,7 @@ def check_convergence(f_vec, n_total, tolf, check, f, dflux, tolmin, temp, temp_
         
         flag_converge = 2
         return flag_converge , check
+
     if check == True :
         test = 0.0
         den1 = max(f,0.5*(n_total))
@@ -1049,7 +1074,7 @@ def growdown(nlv,nstr, ngrow) :
 def get_fluxes( pressure, temperature, dwni,  bb , y2, tp, tmin, tmax ,DTAU, TAU, W0, 
             COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, 
             ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , 
-            wno,nwno,ng,nt, nlevel, ngauss, gauss_wts,reflected, thermal):
+            wno,nwno,ng,nt,gweight,tweight, nlevel, ngauss, gauss_wts,reflected, thermal):
     """
     Program to run RT for climate calculations. Runs the thermal and reflected module.
     And combines the results with wavenumber widths.
@@ -1094,20 +1119,23 @@ def get_fluxes( pressure, temperature, dwni,  bb , y2, tp, tmin, tmax ,DTAU, TAU
     flux_plus_v= np.zeros(shape=(ng,nt,nlevel,nwno)) # level plus visible fluxes
     flux_minus_v= np.zeros(shape=(ng,nt,nlevel,nwno)) # level minus visible fluxes
     
-    """<<<<<<< NEWCLIMA
+    #"""<<<<<<< NEWCLIMA
     # for thermal
     flux_plus_midpt = np.zeros(shape=(ng,nt,nlevel,nwno))
     flux_minus_midpt = np.zeros(shape=(ng,nt,nlevel,nwno))
 
     flux_plus = np.zeros(shape=(ng,nt,nlevel,nwno))
     flux_minus = np.zeros(shape=(ng,nt,nlevel,nwno))
-    """
+    #"""
+
+    """<<<<<<< OG
     # for thermal
     flux_plus_midpt = np.zeros(shape=(nlevel,nwno))
     flux_minus_midpt = np.zeros(shape=(nlevel,nwno))
 
     flux_plus = np.zeros(shape=(nlevel,nwno))
     flux_minus = np.zeros(shape=(nlevel,nwno))
+    """
 
     # outputs needed for climate
     flux_net_ir = np.zeros(shape=(nlevel)) #net level visible fluxes
@@ -1117,8 +1145,8 @@ def get_fluxes( pressure, temperature, dwni,  bb , y2, tp, tmin, tmax ,DTAU, TAU
     flux_minus_ir= np.zeros(shape=(nlevel,nwno)) # level minus visible fluxes
 
     
-    ugauss_angles= np.array([0.0985350858,0.3045357266,0.5620251898,0.8019865821,0.9601901429])    
-    ugauss_weights = np.array([0.0157479145,0.0739088701,0.1463869871,0.1671746381,0.0967815902])
+    #ugauss_angles= np.array([0.0985350858,0.3045357266,0.5620251898,0.8019865821,0.9601901429])    
+    #ugauss_weights = np.array([0.0157479145,0.0739088701,0.1463869871,0.1671746381,0.0967815902])
     #ugauss_angles = np.array([0.66666])
     #ugauss_weights = np.array([0.5])
 
@@ -1150,14 +1178,19 @@ def get_fluxes( pressure, temperature, dwni,  bb , y2, tp, tmin, tmax ,DTAU, TAU
 
             ======="""
             #nlevel = atm.c.nlevel
+
+            ng_clima,nt_clima=1,1
+            ubar0_clima = ubar0*0+0.5
+            ubar1_clima = ubar1*0+0.5
+
             RSFV = 0.01 # from tgmdat.f of EGP
             
             b_surface = 0.0 +RSFV*ubar0[0]*FOPI*np.exp(-TAU[-1,:,ig]/ubar0[0])
             
             delta_approx = 0 # assuming delta approx is already applied on opds 
                         
-            flux_minus_all_v, flux_plus_all_v, flux_minus_midpt_all_v, flux_plus_midpt_all_v = get_reflected_1d_gfluxv(nlevel, wno,nwno, ng,nt, DTAU[:,:,ig], TAU[:,:,ig], W0[:,:,ig], COSB[:,:,ig],
-                                                                                       surf_reflect,b_top,b_surface,ubar0, FOPI,tridiagonal, delta_approx)
+            flux_minus_all_v, flux_plus_all_v, flux_minus_midpt_all_v, flux_plus_midpt_all_v = get_reflected_1d_gfluxv(nlevel, wno,nwno, ng_clima,nt_clima, DTAU[:,:,ig], TAU[:,:,ig], W0[:,:,ig], COSB[:,:,ig],
+                                                                                       surf_reflect,b_top,b_surface,ubar0_clima, FOPI,tridiagonal, delta_approx)
             
 
             flux_net_v_layer += (np.sum(flux_plus_midpt_all_v,axis=3)-np.sum(flux_minus_midpt_all_v,axis=3))*gauss_wts[ig]
@@ -1169,7 +1202,6 @@ def get_fluxes( pressure, temperature, dwni,  bb , y2, tp, tmin, tmax ,DTAU, TAU
         #if full output is requested add in xint at top for 3d plots
 
 
-    #thermal=1
     if thermal:
 
         #use toon method (and tridiagonal matrix solver) to get net cumulative fluxes 
@@ -1179,42 +1211,45 @@ def get_fluxes( pressure, temperature, dwni,  bb , y2, tp, tmin, tmax ,DTAU, TAU
             #remember all OG values (e.g. no delta eddington correction) go into thermal as well as 
             #the uncorrected raman single scattering 
             
-            """<<<<<<< NEWCLIMA
+            #"""<<<<<<< NEWCLIMA
             hard_surface = 0 
             _,out_therm_fluxes = get_thermal_1d_newclima(nlevel, wno,nwno,ng,nt,temperature,
                                             DTAU_OG[:,:,ig], W0_no_raman[:,:,ig], COSB_OG[:,:,ig], 
                                             pressure,ubar1,
-                                            surf_reflect, hard_surface, tridiagonal)
-            flux_minus_all_i, flux_plus_all_i, flux_minus_midpt_all_i, flux_plus_midpt_all_i = out_therm_fluxes
+                                            surf_reflect, hard_surface, dwni, calc_type=1)
 
+            flux_minus_all_i, flux_plus_all_i, flux_minus_midpt_all_i, flux_plus_midpt_all_i = out_therm_fluxes
 
             flux_plus += flux_plus_all_i*gauss_wts[ig]
             flux_minus += flux_minus_all_i*gauss_wts[ig]
-            """
-
+            flux_plus_midpt += flux_plus_midpt_all_i*gauss_wts[ig]#*weights
+            flux_minus_midpt += flux_minus_midpt_all_i*gauss_wts[ig]#*weights
+            #"""
+            
+            """<<<<<<< OG CODE
             calc_type=1 # this line might change depending on Natasha's new function
             
             #for iubar,weights in zip(ugauss_angles,ugauss_weights):
-            flux_minus_all_i, flux_plus_all_i, flux_minus_midpt_all_i, flux_plus_midpt_all_i=get_thermal_1d_gfluxi(nlevel,wno,nwno,ng,nt,temperature,DTAU_OG[:,:,ig], W0_no_raman[:,:,ig], COSB_OG[:,:,ig], pressure,ubar1,surf_reflect, ugauss_angles,ugauss_weights, tridiagonal,calc_type, dwni)#bb , y2, tp, tmin, tmax)
+            flux_minus_all_i, flux_plus_all_i, flux_minus_midpt_all_i, flux_plus_midpt_all_i=get_thermal_1d_gfluxi(nlevel,wno,nwno,ng,nt,temperature,DTAU_OG[:,:,ig], W0_no_raman[:,:,ig], COSB_OG[:,:,ig], pressure,ubar1,surf_reflect, ugauss_angles,ugauss_weights, tridiagonal,calc_type, dwni)#,bb , y2, tp, tmin, tmax)
 
             flux_plus += flux_plus_all_i*gauss_wts[ig]#*weights
             flux_minus += flux_minus_all_i*gauss_wts[ig]#*weights
 
             flux_plus_midpt += flux_plus_midpt_all_i*gauss_wts[ig]#*weights
             flux_minus_midpt += flux_minus_midpt_all_i*gauss_wts[ig]#*weights
+            """
 
-
-        """<<<<<<< NEWCLIMA
+        #"""<<<<<<< NEWCLIMA
         #compresses in gauss-chebyshev angle space 
         #the integration over the "disk" of the planet opposed to the 
         #other gauss angles which are for the correlatedk tables
-        gweight = np.array([0.01574791, 0.07390887, 0.14638699, 0.16717464, 0.09678159])
-        tweight = np.array([6.28318531])
+        #gweight = np.array([0.01574791, 0.07390887, 0.14638699, 0.16717464, 0.09678159])
+        #tweight = np.array([1])#[6.28318531])
         flux_plus = compress_thermal(nwno, flux_plus, gweight, tweight)
         flux_minus= compress_thermal(nwno, flux_minus, gweight, tweight)
         flux_plus_midpt= compress_thermal(nwno, flux_plus_midpt, gweight, tweight)
         flux_minus_midpt= compress_thermal(nwno, flux_minus_midpt, gweight, tweight)
-        """
+        #"""
 
         for wvi in range(nwno):
             flux_net_ir_layer += (flux_plus_midpt[:,wvi]-flux_minus_midpt[:,wvi]) * dwni[wvi]
@@ -1222,8 +1257,12 @@ def get_fluxes( pressure, temperature, dwni,  bb , y2, tp, tmin, tmax ,DTAU, TAU
 
             flux_plus_ir[:,wvi] += flux_plus[:,wvi] * dwni[wvi]
             flux_minus_ir[:,wvi] += flux_minus[:,wvi] * dwni[wvi]
-
-
+        """
+        print('debug fluxes in get_fluxes', temperature)
+        for wvi in range(nwno):
+            for il in range(len(flux_plus_midpt[:,0])):
+                print(wvi, dwni[wvi],flux_plus_midpt[il,wvi],flux_minus_midpt[il,wvi] )
+        """
 
         #if full output is requested add in flux at top for 3d plots
     
@@ -1280,24 +1319,22 @@ def calculate_atm(bundle, opacityclass):
     #get geometry
     geom = inputs['disco']
 
-    """ NEWCLIMA
+    #""" NEWCLIMA
     ng, nt = geom['num_gangle'], geom['num_tangle']#1,1 #
     gangle,gweight,tangle,tweight = geom['gangle'], geom['gweight'],geom['tangle'], geom['tweight']
     lat, lon = geom['latitude'], geom['longitude']
     cos_theta = geom['cos_theta']
     ubar0, ubar1 = geom['ubar0'], geom['ubar1']
-    """
-    ng, nt = 1,1 #geom['num_gangle'], geom['num_tangle']
+    #"""
+    """ OG Code
+    ng, nt = 1,1
     gangle,gweight,tangle,tweight = geom['gangle'], geom['gweight'],geom['tangle'], geom['tweight']
     lat, lon = geom['latitude'], geom['longitude']
     cos_theta = geom['cos_theta']
-    #ubar0, ubar1 = geom['ubar0'], geom['ubar1']
-    #print(np.shape(ubar0),ubar0[0])
     ubar0,ubar1 = np.zeros((5,1)),np.zeros((5,1))
     ubar0 += 0.5
     ubar1 += 0.5
-    #print(ubar0,ubar1)
-
+    """
     #set star parameters
     radius_star = inputs['star']['radius']
 
@@ -1356,7 +1393,7 @@ def calculate_atm(bundle, opacityclass):
     #mmw = np.mean(atm.layer['mmw'])
     mmw = atm.layer['mmw']
     
-    return DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , atm.surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw
+    return DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , atm.surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw,gweight,tweight
 
 
 def calculate_atm_deq(bundle, opacityclass,on_fly=False,gases_fly=None):

--- a/picaso/climate.py
+++ b/picaso/climate.py
@@ -333,7 +333,8 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
             grad, cp, tidal, tmin,tmax, dwni , bb , y2, tp, DTAU, TAU, W0, COSB, 
             ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, ubar0,ubar1,
             cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,
-            constant_back,constant_forward,  wno,nwno,ng,nt,gweight,tweight, ngauss, gauss_wts, save_profile, all_profiles):
+            constant_back,constant_forward,  wno,nwno,ng,nt,gweight,tweight, ngauss, gauss_wts, save_profile, all_profiles,
+            verbose):
     """
     Module to iterate on the level TP profile to make the Net Flux as close to 0.
     Opacities/chemistry are not updated while iterating in this module.
@@ -388,6 +389,9 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
         Output of set_bb function in fluxes.py
     tp : array
         Output of set_bb function in fluxes.py
+    verbose : int
+        If verbose=0, nothing will print out
+        If verbose=1, everything will print out during the run, 
     
     Returns
     -------

--- a/picaso/disco.py
+++ b/picaso/disco.py
@@ -108,7 +108,7 @@ def get_angles_3d(num_gangle, num_tangle):
 
     return gangle,gweight,tangle,tweight
 
-@jit(nopython=True, cache=True)
+#@jit(nopython=True, cache=True)
 def compress_disco( nwno, cos_theta, xint_at_top, gweight, tweight,F0PI): 
     """
     Last step in albedo code. Integrates over phase angle based on the 

--- a/picaso/fluxes.py
+++ b/picaso/fluxes.py
@@ -1648,7 +1648,7 @@ def blackbody(t,w):
     return ((2.0*h*c**2.0)/(w**5.0))*(1.0/(exp((h*c)/outer(t, w*k)) - 1.0)) #* (w*w)
 
 @jit(nopython=True, cache=True)
-def get_thermal_1d_newclima(nlevel, wno,nwno, numg,numt,tlevel, dtau, w0,cosb,plevel, ubar1,
+def get_thermal_1d(nlevel, wno,nwno, numg,numt,tlevel, dtau, w0,cosb,plevel, ubar1,
     surf_reflect, hard_surface, dwno, calc_type):
     """
     This function uses the source function method, which is outlined here : 
@@ -1878,7 +1878,7 @@ def get_thermal_1d_newclima(nlevel, wno,nwno, numg,numt,tlevel, dtau, w0,cosb,pl
     return flux_at_top , (flux_minus, flux_plus, flux_minus_mdpt, flux_plus_mdpt)
 
 @jit(nopython=True, cache=True)
-def get_thermal_1d(nlevel, wno,nwno, numg,numt,tlevel, dtau, w0,cosb,plevel, ubar1,
+def get_thermal_1d_deprecate(nlevel, wno,nwno, numg,numt,tlevel, dtau, w0,cosb,plevel, ubar1,
     surf_reflect, hard_surface, tridiagonal):
     """
     This function uses the source function method, which is outlined here : 
@@ -2319,7 +2319,7 @@ def get_thermal_3d(nlevel, wno,nwno, numg,numt,tlevel_3d, dtau_3d, w0_3d,cosb_3d
     return int_at_top #, int_down# numg x numt x nwno
 
 @jit(nopython=True, cache=True)
-def get_thermal_1d_gfluxi(nlevel, wno,nwno, numg,numt,tlevel, dtau, w0,cosb,plevel, ubar1,surf_reflect,ugauss_angles,ugauss_weights, tridiagonal, calc_type ,dwno): 
+def get_thermal_1d_gfluxi_deprecate(nlevel, wno,nwno, numg,numt,tlevel, dtau, w0,cosb,plevel, ubar1,surf_reflect,ugauss_angles,ugauss_weights, tridiagonal, calc_type ,dwno): 
     #bb , y2, tp, tmin, tmax):
     """
     This function uses the source function method, which is outlined here : 

--- a/picaso/fluxes.py
+++ b/picaso/fluxes.py
@@ -658,7 +658,7 @@ def get_reflected_3d(nlevel, wno,nwno, numg,numt, dtau_3d, tau_3d, w0_3d, cosb_3
     return xint_at_top
 
 @jit(nopython=True, cache=True)
-def get_reflected_1d(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,gcos2, ftau_cld, ftau_ray,
+def get_reflected_1d_deprecate(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,gcos2, ftau_cld, ftau_ray,
     dtau_og, tau_og, w0_og, cosb_og, 
     surf_reflect,ubar0, ubar1,cos_theta, F0PI,single_phase, multi_phase,
     frac_a, frac_b, frac_c, constant_back, constant_forward,
@@ -1006,7 +1006,7 @@ def get_reflected_1d(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,gcos2, fta
 
 
 @jit(nopython=True, cache=True)
-def get_reflected_1d_newclima(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,gcos2, ftau_cld, ftau_ray,
+def get_reflected_1d(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,gcos2, ftau_cld, ftau_ray,
     dtau_og, tau_og, w0_og, cosb_og, 
     surf_reflect,ubar0, ubar1,cos_theta, F0PI,single_phase, multi_phase,
     frac_a, frac_b, frac_c, constant_back, constant_forward, 

--- a/picaso/fluxes.py
+++ b/picaso/fluxes.py
@@ -6,7 +6,7 @@ import pickle as pk
 from scipy.linalg import solve_banded
 #from numpy.linalg import solve
 
-@jit(nopython=True, cache=True,fastmath=True)
+@jit(nopython=True, cache=True)
 def slice_eq(array, lim, value):
     """Funciton to replace values with upper or lower limit
     """
@@ -16,7 +16,7 @@ def slice_eq(array, lim, value):
         array[i,:] = new     
     return array
 
-@jit(nopython=True, cache=True,fastmath=True)
+@jit(nopython=True, cache=True)
 def slice_lt(array, lim):
     """Funciton to replace values with upper or lower limit
     """
@@ -26,7 +26,7 @@ def slice_lt(array, lim):
         array[i,:] = new     
     return array
 
-@jit(nopython=True, cache=True,fastmath=True)
+@jit(nopython=True, cache=True)
 def slice_gt(array, lim):
     """Funciton to replace values with upper or lower limit
     """
@@ -46,7 +46,7 @@ def slice_rav(array, lim):
     new[where(new<-lim)] = -lim
     return new.reshape(shape)
 
-@jit(nopython=True, cache=True,fastmath=True)
+@jit(nopython=True, cache=True)
 def numba_cumsum(mat):
     """Function to compute cumsum along axis=0 to bypass numba not allowing kwargs in 
     cumsum 
@@ -56,7 +56,7 @@ def numba_cumsum(mat):
         new_mat[:,i] = cumsum(mat[:,i])
     return new_mat
 
-@jit(nopython=True, cache=True)#, fastmath=True)
+@jit(nopython=True, cache=True)
 def setup_tri_diag(nlayer,nwno ,c_plus_up, c_minus_up, 
     c_plus_down, c_minus_down, b_top, b_surface, surf_reflect,
     gama, dtau, exptrm_positive,  exptrm_minus):
@@ -153,7 +153,7 @@ def setup_tri_diag(nlayer,nwno ,c_plus_up, c_minus_up,
 
     return A, B, C, D
 
-@jit(nopython=True, cache=True,fastmath=True)
+@jit(nopython=True, cache=True)
 def setup_pent_diag(nlayer,nwno ,c_plus_up, c_minus_up, 
     c_plus_down, c_minus_down, b_top, b_surface, surf_reflect,
     gama, dtau, exptrm_positive,  exptrm_minus, g1, g2, exptrm, lamda):
@@ -256,7 +256,7 @@ def setup_pent_diag(nlayer,nwno ,c_plus_up, c_minus_up,
     return A, B, C, D, E, F
 
 
-@jit(nopython=True, cache=True)#, fastmath=True)
+@jit(nopython=True, cache=True)
 def tri_diag_solve(l, a, b, c, d):
     """
     Tridiagonal Matrix Algorithm solver, a b c d can be NumPy array type or Python list type.
@@ -977,7 +977,7 @@ def get_reflected_1d(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,gcos2, fta
 #    import sys; sys.exit()
     return xint_at_top #, flux_out, intensity
 
-@jit(nopython=True, cache=True,fastmath=True)
+@jit(nopython=True, cache=True)
 def get_reflected_1d_newclima(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,gcos2, ftau_cld, ftau_ray,
     dtau_og, tau_og, w0_og, cosb_og, 
     surf_reflect,ubar0, ubar1,cos_theta, F0PI,single_phase, multi_phase,
@@ -1349,7 +1349,7 @@ def get_reflected_1d_newclima(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,g
     
     return xint_at_top, (flux_minus_all, flux_plus_all, flux_minus_midpt_all, flux_plus_midpt_all )
 
-@jit(nopython=True, cache=True,fastmath=True)
+@jit(nopython=True, cache=True)
 def get_reflected_1d_gfluxv(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,
     surf_reflect,b_top,b_surface,ubar0, F0PI,tridiagonal, delta_approx):
     """
@@ -1598,7 +1598,7 @@ def blackbody_integrated(T, wave, dwave):
 
     return planck_sum
 
-@jit(nopython=True, cache=True,fastmath=True)
+@jit(nopython=True, cache=True)
 def blackbody(t,w):
     """
     Blackbody flux in cgs units in per unit wavelength (cm)
@@ -3754,7 +3754,7 @@ def planck_cgs_deprecate(wave, T , dwave):
     return planck_sum
 
 
-@jit(nopython=True, cache=True,fastmath=True)
+@jit(nopython=True, cache=True)
 def planck_rad_deprecate(iw, T, dT ,  tmin, tmax, bb , y2, tp):
 
     if T < tmin :

--- a/picaso/fluxes.py
+++ b/picaso/fluxes.py
@@ -1000,9 +1000,7 @@ def get_reflected_1d_deprecate(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,
             xint_at_top[ng,nt,:] = xint[0,:]
             #intensity[ng,nt,:,:] = xint
 
-#    import IPython; IPython.embed()
-#    import sys; sys.exit()
-    return xint_at_top #, flux_out, intensity
+    return xint_at_top 
 
 
 @jit(nopython=True, cache=True)

--- a/picaso/fluxes.py
+++ b/picaso/fluxes.py
@@ -1410,7 +1410,7 @@ def get_reflected_1d_newclima(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,g
     return xint_at_top, (flux_minus_all, flux_plus_all, flux_minus_midpt_all, flux_plus_midpt_all )
 
 @jit(nopython=True, cache=True)
-def get_reflected_1d_gfluxv(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,
+def get_reflected_1d_gfluxv_deprecate(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,
     surf_reflect,b_top,b_surface,ubar0, F0PI,tridiagonal, delta_approx):
     """
     Computes upwelling and downwelling layer and level toon fluxes given tau and everything is 1 dimensional. This is the exact same function 

--- a/picaso/fluxes.py
+++ b/picaso/fluxes.py
@@ -356,7 +356,7 @@ def pent_diag_solve(l, A, B, C, D, E, F):
 def get_reflected_3d(nlevel, wno,nwno, numg,numt, dtau_3d, tau_3d, w0_3d, cosb_3d,gcos2_3d, ftau_cld_3d,ftau_ray_3d,
     dtau_og_3d, tau_og_3d, w0_og_3d, cosb_og_3d, 
     surf_reflect,ubar0, ubar1,cos_theta, F0PI,single_phase, multi_phase,
-    frac_a, frac_b, frac_c, constant_back, constant_forward,tridiagonal):
+    frac_a, frac_b, frac_c, constant_back, constant_forward):
     """
     Computes toon fluxes given tau and everything is 3 dimensional. This is the exact same function 
     as `get_flux_geom_1d` but is kept separately so we don't have to do unecessary indexing for 
@@ -439,8 +439,7 @@ def get_reflected_3d(nlevel, wno,nwno, numg,numt, dtau_3d, tau_3d, w0_3d, cosb_3
     constant_forward : float 
         (Optional), If using the TTHG phase function. Must specify the assymetry of forward scatterer. 
         Remember, the output of A & M code does not separate back and forward scattering.
-    tridiagonal : int 
-        0 for tridiagonal, 1 for pentadiagonal 
+
     Returns
     -------
     intensity at the top of the atmosphere for all the different ubar1 and ubar2 
@@ -525,11 +524,11 @@ def get_reflected_3d(nlevel, wno,nwno, numg,numt, dtau_3d, tau_3d, w0_3d, cosb_3
             b_surface = 0. + surf_reflect*ubar0[ng, nt]*F0PI*exp(-tau[-1, :]/ubar0[ng, nt])
 
             #Now we need the terms for the tridiagonal rotated layered method
-            if tridiagonal==0:
-                A, B, C, D = setup_tri_diag(nlayer,nwno,  c_plus_up, c_minus_up, 
-                                    c_plus_down, c_minus_down, b_top, b_surface, surf_reflect,
-                                     gama, dtau, 
-                                    exptrm_positive,  exptrm_minus) 
+            #if tridiagonal==0:
+            A, B, C, D = setup_tri_diag(nlayer,nwno,  c_plus_up, c_minus_up, 
+                                c_plus_down, c_minus_down, b_top, b_surface, surf_reflect,
+                                 gama, dtau, 
+                                exptrm_positive,  exptrm_minus) 
             #else:
             #   A_, B_, C_, D_, E_, F_ = setup_pent_diag(nlayer,nwno,  c_plus_up, c_minus_up, 
             #                       c_plus_down, c_minus_down, b_top, b_surface, surf_reflect,
@@ -542,11 +541,11 @@ def get_reflected_3d(nlevel, wno,nwno, numg,numt, dtau_3d, tau_3d, w0_3d, cosb_3
             L = 2*nlayer
             for w in range(nwno):
                 #coefficient of posive and negative exponential terms 
-                if tridiagonal==0:
-                    X = tri_diag_solve(L, A[:,w], B[:,w], C[:,w], D[:,w])
-                    #unmix the coefficients
-                    positive[:,w] = X[::2] + X[1::2] 
-                    negative[:,w] = X[::2] - X[1::2]
+                #if tridiagonal==0:
+                X = tri_diag_solve(L, A[:,w], B[:,w], C[:,w], D[:,w])
+                #unmix the coefficients
+                positive[:,w] = X[::2] + X[1::2] 
+                negative[:,w] = X[::2] - X[1::2]
                 #else:
                 #   X = pent_diag_solve(L, A_[:,w], B_[:,w], C_[:,w], D_[:,w], E_[:,w], F_[:,w])
                 #   #unmix the coefficients
@@ -663,7 +662,7 @@ def get_reflected_1d(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,gcos2, fta
     dtau_og, tau_og, w0_og, cosb_og, 
     surf_reflect,ubar0, ubar1,cos_theta, F0PI,single_phase, multi_phase,
     frac_a, frac_b, frac_c, constant_back, constant_forward,
-    toon_coefficients=0, tridiagonal=0, b_top=0):
+    toon_coefficients=0,b_top=0):
     """
     Computes toon fluxes given tau and everything is 1 dimensional. This is the exact same function 
     as `get_flux_geom_3d` but is kept separately so we don't have to do unecessary indexing for fast
@@ -746,8 +745,6 @@ def get_reflected_1d(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,gcos2, fta
     constant_forward : float 
         (Optional), If using the TTHG phase function. Must specify the assymetry of forward scatterer. 
         Remember, the output of A & M code does not separate back and forward scattering.
-    tridiagonal : int 
-        0 for tridiagonal, 1 for pentadiagonal 
     toon_coefficients : int     
         0 for quadrature (default) 1 for eddington
 
@@ -826,11 +823,11 @@ def get_reflected_1d(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,gcos2, fta
             b_surface = 0. + surf_reflect*u0*F0PI*exp(-tau[-1, :]/u0)
 
             #Now we need the terms for the tridiagonal rotated layered method
-            if tridiagonal==0:
-                A, B, C, D = setup_tri_diag(nlayer,nwno,  c_plus_up, c_minus_up, 
-                                    c_plus_down, c_minus_down, b_top, b_surface, surf_reflect,
-                                     gama, dtau, 
-                                    exptrm_positive,  exptrm_minus) 
+            #if tridiagonal==0:
+            A, B, C, D = setup_tri_diag(nlayer,nwno,  c_plus_up, c_minus_up, 
+                                c_plus_down, c_minus_down, b_top, b_surface, surf_reflect,
+                                 gama, dtau, 
+                                exptrm_positive,  exptrm_minus) 
 
             #else:
             #   A_, B_, C_, D_, E_, F_ = setup_pent_diag(nlayer,nwno,  c_plus_up, c_minus_up, 
@@ -844,11 +841,11 @@ def get_reflected_1d(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,gcos2, fta
             L = 2*nlayer
             for w in range(nwno):
                 #coefficient of posive and negative exponential terms 
-                if tridiagonal==0:
-                    X = tri_diag_solve(L, A[:,w], B[:,w], C[:,w], D[:,w])
-                    #unmix the coefficients
-                    positive[:,w] = X[::2] + X[1::2] 
-                    negative[:,w] = X[::2] - X[1::2]
+                #if tridiagonal==0:
+                X = tri_diag_solve(L, A[:,w], B[:,w], C[:,w], D[:,w])
+                #unmix the coefficients
+                positive[:,w] = X[::2] + X[1::2] 
+                negative[:,w] = X[::2] - X[1::2]
 
                 #else: 
                 #   X = pent_diag_solve(L, A_[:,w], B_[:,w], C_[:,w], D_[:,w], E_[:,w], F_[:,w])
@@ -1007,11 +1004,14 @@ def get_reflected_1d(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,gcos2, fta
 #    import sys; sys.exit()
     return xint_at_top #, flux_out, intensity
 
+
 @jit(nopython=True, cache=True)
 def get_reflected_1d_newclima(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,gcos2, ftau_cld, ftau_ray,
     dtau_og, tau_og, w0_og, cosb_og, 
     surf_reflect,ubar0, ubar1,cos_theta, F0PI,single_phase, multi_phase,
-    frac_a, frac_b, frac_c, constant_back, constant_forward, tridiagonal,get_toa_intensity,get_lvl_flux):
+    frac_a, frac_b, frac_c, constant_back, constant_forward, 
+    get_toa_intensity=1,get_lvl_flux=0,
+    toon_coefficients=0,b_top=0):
     """
     Computes toon fluxes given tau and everything is 1 dimensional. This is the exact same function 
     as `get_flux_geom_3d` but is kept separately so we don't have to do unecessary indexing for fast
@@ -1094,15 +1094,18 @@ def get_reflected_1d_newclima(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,g
     constant_forward : float 
         (Optional), If using the TTHG phase function. Must specify the assymetry of forward scatterer. 
         Remember, the output of A & M code does not separate back and forward scattering.
-    tridiagonal : int 
-        0 for tridiagonal, 1 for pentadiagonal 
+    get_toa_intensity : int 
+        (Optional) Default=1 is to only return the TOA intensity you would need for a 1D spectrum (1)
+        otherwise it will return zeros for TOA intensity 
+    get_lvl_flux : int 
+        (Optional) Default=0 is to only compute TOA intensity and NOT return the lvl fluxes so this needs 
+        to be flipped on for the climate calculations
+    toon_coefficients : int     
+        (Optional) 0 for quadrature (default) 1 for eddington
+
     Returns
     -------
     intensity at the top of the atmosphere for all the different ubar1 and ubar2 
-    To Do
-    -----
-    - F0PI Solar flux shouldn't always be 1.. Follow up to make sure that this isn't a bad 
-          hardwiring to solar, despite "relative albedo"
     """
     #these are only filled in if get_toa_intensity=1
     #outgoing intensity as a function of all the different angles
@@ -1126,32 +1129,41 @@ def get_reflected_1d_newclima(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,g
 
     #terms not dependent on incident angle
     sq3 = sqrt(3.)
-    g1  = (sq3*0.5)*(2. - w0*(1.+cosb)) #table 1 # (7-w0*(4+3*cosb))/4 #
-    g2  = (sq3*w0*0.5)*(1.-cosb)        #table 1 # -(1-w0*(4-3*cosb))/4 #
+    if toon_coefficients == 1:#eddington
+        g1  = (7-w0*(4+3*ftau_cld*cosb))/4 #(sq3*0.5)*(2. - w0*(1.+cosb)) #table 1 # 
+        g2  = -(1-w0*(4-3*ftau_cld*cosb))/4 #(sq3*w0*0.5)*(1.-cosb)        #table 1 # 
+    elif toon_coefficients == 0:#quadrature
+        g1  = (sq3*0.5)*(2. - w0*(1.+ftau_cld*cosb)) #table 1 # 
+        g2  = (sq3*w0*0.5)*(1.-ftau_cld*cosb)        #table 1 # 
+
     lamda = sqrt(g1**2 - g2**2)         #eqn 21
     gama  = (g1-lamda)/g2               #eqn 22
 
     #================ START CRAZE LOOP OVER ANGLE #================
     for ng in range(numg):
         for nt in range(numt):
-
-            g3  = 0.5*(1.-sq3*cosb*ubar0[ng, nt]) #(2-3*cosb*ubar0[ng,nt])/4#  #table 1 #ubar has dimensions [gauss angles by tchebyshev angles ]
+            u1 = ubar1[ng,nt]
+            u0 = ubar0[ng,nt]
+            if toon_coefficients == 1 : #eddington
+                g3  = (2-3*ftau_cld*cosb*u0)/4#0.5*(1.-sq3*cosb*ubar0[ng, nt]) #  #table 1 #ubar has dimensions [gauss angles by tchebyshev angles ]
+            elif toon_coefficients == 0 :#quadrature
+                g3  = 0.5*(1.-sq3*ftau_cld*cosb*u0) #  #table 1 #ubar has dimensions [gauss angles by tchebyshev angles ]
     
             # now calculate c_plus and c_minus (equation 23 and 24 toon)
             g4 = 1.0 - g3
-            denominator = lamda**2 - 1.0/ubar0[ng, nt]**2.0
+            denominator = lamda**2 - 1.0/u0**2.0
 
             #everything but the exponential 
-            a_minus = F0PI*w0* (g4*(g1 + 1.0/ubar0[ng, nt]) +g2*g3 ) / denominator
-            a_plus  = F0PI*w0*(g3*(g1-1.0/ubar0[ng, nt]) +g2*g4) / denominator
+            a_minus = F0PI*w0* (g4*(g1 + 1.0/u0) +g2*g3 ) / denominator
+            a_plus  = F0PI*w0*(g3*(g1-1.0/u0) +g2*g4) / denominator
 
             #add in exponential to get full eqn
             #_up is the terms evaluated at lower optical depths (higher altitudes)
             #_down is terms evaluated at higher optical depths (lower altitudes)
-            x = exp(-tau[:-1,:]/ubar0[ng, nt])
+            x = exp(-tau[:-1,:]/u0)
             c_minus_up = a_minus*x #CMM1
             c_plus_up  = a_plus*x #CPM1
-            x = exp(-tau[1:,:]/ubar0[ng, nt])
+            x = exp(-tau[1:,:]/u0)
             c_minus_down = a_minus*x #CM
             c_plus_down  = a_plus*x #CP
 
@@ -1165,13 +1177,13 @@ def get_reflected_1d_newclima(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,g
 
 
             #boundary conditions 
-            b_top = 0.0                                       
+            #b_top = 0.0                                       
 
-            b_surface = 0. + surf_reflect*ubar0[ng, nt]*F0PI*exp(-tau[-1, :]/ubar0[ng, nt])
+            b_surface = 0. + surf_reflect*u0*F0PI*exp(-tau[-1, :]/u0)
 
             #Now we need the terms for the tridiagonal rotated layered method
-            if tridiagonal==0:
-                A, B, C, D = setup_tri_diag(nlayer,nwno,  c_plus_up, c_minus_up, 
+            #if tridiagonal==0:
+            A, B, C, D = setup_tri_diag(nlayer,nwno,  c_plus_up, c_minus_up, 
                                     c_plus_down, c_minus_down, b_top, b_surface, surf_reflect,
                                      gama, dtau, 
                                     exptrm_positive,  exptrm_minus) 
@@ -1188,17 +1200,18 @@ def get_reflected_1d_newclima(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,g
             L = 2*nlayer
             for w in range(nwno):
                 #coefficient of posive and negative exponential terms 
-                if tridiagonal==0:
-                    X = tri_diag_solve(L, A[:,w], B[:,w], C[:,w], D[:,w])
-                    #unmix the coefficients
-                    positive[:,w] = X[::2] + X[1::2] 
-                    negative[:,w] = X[::2] - X[1::2]
+                #if tridiagonal==0:
+                X = tri_diag_solve(L, A[:,w], B[:,w], C[:,w], D[:,w])
+                #unmix the coefficients
+                positive[:,w] = X[::2] + X[1::2] 
+                negative[:,w] = X[::2] - X[1::2]
 
                 #else: 
                 #   X = pent_diag_solve(L, A_[:,w], B_[:,w], C_[:,w], D_[:,w], E_[:,w], F_[:,w])
                     #unmix the coefficients
                 #   positive[:,w] = exptrm_minus[:,w] * (X[::2] + X[1::2])
                 #   negative[:,w] = X[::2] - X[1::2]
+
             #========================= End loop over wavelength =========================
 
             #========================= Get fluxes if needed for climate =========================
@@ -1219,7 +1232,7 @@ def get_reflected_1d_newclima(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,g
                 flux_minus[-1, :], flux_plus[-1, :] = flux_zero_minus, flux_zero_plus 
                 
                 #add in direct flux term to the downwelling radiation, liou 182
-                flux_minus = flux_minus + ubar0[ng, nt]*F0PI*exp(-tau/ubar0[ng, nt])
+                flux_minus = flux_minus + u0*F0PI*exp(-tau/u0)
 
                 #now get midpoint values 
                 exptrm_positive_midpt = exp(0.5*exptrm) #EP
@@ -1244,7 +1257,7 @@ def get_reflected_1d_newclima(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,g
             #========================= End get fluxes if needed for climate =========================
 
 
-            #========================= Get intensities if needed for climate =========================
+            #========================= Get intensities if needed for spectrum =========================
             if get_toa_intensity:
                 ################################ BEGIN OPTIONS FOR MULTIPLE SCATTERING####################
                 #use expression for bottom flux to get the flux_plus and flux_minus at last
@@ -1264,13 +1277,13 @@ def get_reflected_1d_newclima(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,g
                     #this is a decent assumption because our second order legendre polynomial 
                     #is forced to be equal to the rayleigh phase function
                     ubar2 = 0.767  # 
-                    multi_plus = (1.0+1.5*cosb*ubar1[ng,nt] #!was 3
-                                    + gcos2*(3.0*ubar2*ubar2*ubar1[ng,nt]*ubar1[ng,nt] - 1.0)/2.0)
-                    multi_minus = (1.-1.5*cosb*ubar1[ng,nt] 
-                                    + gcos2*(3.0*ubar2*ubar2*ubar1[ng,nt]*ubar1[ng,nt] - 1.0)/2.0)
+                    multi_plus = (1.0+1.5*ftau_cld*cosb*u1 #!was 3
+                                    + gcos2*(3.0*ubar2*ubar2*u1*u1 - 1.0)/2.0)
+                    multi_minus = (1.-1.5*ftau_cld*cosb*u1 
+                                    + gcos2*(3.0*ubar2*ubar2*u1*u1 - 1.0)/2.0)
                 elif multi_phase ==1:#'N=1':
-                    multi_plus = 1.0+1.5*cosb*ubar1[ng,nt]  
-                    multi_minus = 1.-1.5*cosb*ubar1[ng,nt]
+                    multi_plus = 1.0+1.5*ftau_cld*cosb*u1  
+                    multi_minus = 1.-1.5*ftau_cld*cosb*u1
                 ################################ end options for multiple scatteirng ####################
 
                 G=positive*(multi_plus+gama*multi_minus)    *w0
@@ -1338,44 +1351,61 @@ def get_reflected_1d_newclima(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,g
                                 )
                             )
                 #exploring.... 
-                elif single_phase==4:#'P(HG) exact w/ approx costheta'
-                    deltaphi=0
-                    cos_theta_approx = (-ubar0[ng,nt])*ubar1[ng,nt] + sqrt(1-ubar1[ng,nt]**2)*sqrt(1-ubar0[ng,nt]**2)*cos(deltaphi)
-                    
-                    HG_forward =  (1-g_forward**2) /sqrt((1+g_forward**2+2*g_forward*cos_theta_approx)**3)    
-                    HG_back = (1-g_back**2)/sqrt((1+g_back**2+2*g_back*cos_theta_approx)**3)
+                #elif single_phase==4:#'P(HG) exact w/ approx costheta'
+                #    deltaphi=0
+                #    cos_theta_approx = (-ubar0[ng,nt])*ubar1[ng,nt] + sqrt(1-ubar1[ng,nt]**2)*sqrt(1-ubar0[ng,nt]**2)*cos(deltaphi)
+                #    
+                #    HG_forward =  (1-g_forward**2) /sqrt((1+g_forward**2+2*g_forward*cos_theta_approx)**3)    
+                #    HG_back = (1-g_back**2)/sqrt((1+g_back**2+2*g_back*cos_theta_approx)**3)
 
-                    p_single=(
-                            ftau_cld * (          #opacity of cloud / total opacity
-                                f * HG_forward  + #first term of TTHG: forward scattering
-                                (1-f) * HG_back   #second term of TTHG: backward scattering  
-                                )+  
-                            ftau_ray * (
-                                0.75*(1+cos_theta_approx**2.0) #rayleigh phase function
-                                )
-                            )
+                #    p_single=(
+                #            ftau_cld * (          #opacity of cloud / total opacity
+                #                f * HG_forward  + #first term of TTHG: forward scattering
+                #                (1-f) * HG_back   #second term of TTHG: backward scattering  
+                #                )+  
+                #            ftau_ray * (
+                #                0.75*(1+cos_theta_approx**2.0) #rayleigh phase function
+                #                )
+                #            )
 
                 
                 ################################ end options for direct scattering ####################
 
+                #in codes like DISORT the single and multiple scattering beams are reported separately
+                #in Rooney et al. 2023a we needed to separate these to 
+                #single_scat = zeros((nlevel,nwno))
+                #multi_scat = zeros((nlevel,nwno))
                 for i in range(nlayer-1,-1,-1):
+                    #single_scat[i,:] = ((w0_og[i,:]*F0PI/(4.*pi))
+                    #        *(p_single[i,:])*exp(-tau_og[i,:]/u0)
+                    #        *(1. - exp(-dtau_og[i,:]*(u0+u1)
+                    #        /(u0*u1)))*
+                    #        (u0/(u0+u1)))
+
+                    #multi_scat[i,:] = (A[i,:]*(1. - exp(-dtau[i,:] *(u0+1*u1)/(u0*u1)))*
+                    #        (u0/(u0+1*u1))
+                    #        +G[i,:]*(exp(exptrm[i,:]*1-dtau[i,:]/u1) - 1.0)/(lamda[i,:]*1*u1 - 1.0)
+                    #        +H[i,:]*(1. - exp(-exptrm[i,:]*1-dtau[i,:]/u1))/(lamda[i,:]*1*u1 + 1.0)
+                    #        )
+
                     #direct beam
-                    xint[i,:] =( xint[i+1,:]*exp(-dtau[i,:]/ubar1[ng,nt]) 
+                    xint[i,:] =( xint[i+1,:]*exp(-dtau[i,:]/u1) 
                             #single scattering albedo from sun beam (from ubar0 to ubar1)
                             +(w0_og[i,:]*F0PI/(4.*pi))
-                            *(p_single[i,:])*exp(-tau_og[i,:]/ubar0[ng,nt])
-                            *(1. - exp(-dtau_og[i,:]*(ubar0[ng,nt]+ubar1[ng,nt])
-                            /(ubar0[ng,nt]*ubar1[ng,nt])))*
-                            (ubar0[ng,nt]/(ubar0[ng,nt]+ubar1[ng,nt]))
+                            *(p_single[i,:])*exp(-tau_og[i,:]/u0)
+                            *(1. - exp(-dtau_og[i,:]*(u0+u1)
+                            /(u0*u1)))*
+                            (u0/(u0+u1))
                             #multiple scattering terms p_single
-                            +A[i,:]*(1. - exp(-dtau[i,:] *(ubar0[ng,nt]+1*ubar1[ng,nt])/(ubar0[ng,nt]*ubar1[ng,nt])))*
-                            (ubar0[ng,nt]/(ubar0[ng,nt]+1*ubar1[ng,nt]))
-                            +G[i,:]*(exp(exptrm[i,:]*1-dtau[i,:]/ubar1[ng,nt]) - 1.0)/(lamda[i,:]*1*ubar1[ng,nt] - 1.0)
-                            +H[i,:]*(1. - exp(-exptrm[i,:]*1-dtau[i,:]/ubar1[ng,nt]))/(lamda[i,:]*1*ubar1[ng,nt] + 1.0)
+                            +A[i,:]*(1. - exp(-dtau[i,:] *(u0+1*u1)/(u0*u1)))*
+                            (u0/(u0+1*u1))
+                            +G[i,:]*(exp(exptrm[i,:]*1-dtau[i,:]/u1) - 1.0)/(lamda[i,:]*1*u1 - 1.0)
+                            +H[i,:]*(1. - exp(-exptrm[i,:]*1-dtau[i,:]/u1))/(lamda[i,:]*1*u1 + 1.0)
                             )
 
+
                 xint_at_top[ng,nt,:] = xint[0,:]
-            #========================= End get intensities if needed for climate =========================
+            #========================= End get intensities if needed for spectrum =========================
     
     return xint_at_top, (flux_minus_all, flux_plus_all, flux_minus_midpt_all, flux_plus_midpt_all )
 
@@ -1422,7 +1452,6 @@ def get_reflected_1d_gfluxv(nlevel, wno,nwno, numg,numt, dtau, tau, w0, cosb,
         Surface Boundary Conditions
     ubar0 : ndarray of float 
         matrix of cosine of the incident angle from geometric.json
-    
     F0PI : array 
         Downward incident solar radiation
     delta_approx : int 
@@ -2112,7 +2141,7 @@ def get_thermal_1d_deprecate(nlevel, wno,nwno, numg,numt,tlevel, dtau, w0,cosb,p
 
 @jit(nopython=True, cache=True)
 def get_thermal_3d(nlevel, wno,nwno, numg,numt,tlevel_3d, dtau_3d, w0_3d,cosb_3d,plevel_3d, ubar1,
-    surf_reflect, hard_surface, tridiagonal):
+    surf_reflect, hard_surface):
     """
     This function uses the source function method, which is outlined here : 
     https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/JD094iD13p16287
@@ -2159,8 +2188,7 @@ def get_thermal_3d(nlevel, wno,nwno, numg,numt,tlevel_3d, dtau_3d, w0_3d,cosb_3d
     ubar1 : numpy.ndarray
         This is a matrix of ng by nt. This describes the outgoing incident angles and is generally
         computed in `picaso.disco`
-    tridiagonal : int 
-        Zero for tridiagonal solver. 1 for pentadiagonal (not yet implemented)
+
     Returns
     -------
     numpy.ndarray
@@ -2224,11 +2252,11 @@ def get_thermal_3d(nlevel, wno,nwno, numg,numt,tlevel_3d, dtau_3d, w0_3d,cosb_3d
             else: 
                 b_surface= pi*(all_b[-1,:] + b1[-1,:]*mu1) #(for non terrestrial)
             #Now we need the terms for the tridiagonal rotated layered method
-            if tridiagonal==0:
-                A, B, C, D = setup_tri_diag(nlayer,nwno,  c_plus_up, c_minus_up, 
-                                    c_plus_down, c_minus_down, b_top, b_surface, surf_reflect,
-                                     gama, dtau, 
-                                    exptrm_positive,  exptrm_minus) 
+            #if tridiagonal==0:
+            A, B, C, D = setup_tri_diag(nlayer,nwno,  c_plus_up, c_minus_up, 
+                                c_plus_down, c_minus_down, b_top, b_surface, surf_reflect,
+                                 gama, dtau, 
+                                exptrm_positive,  exptrm_minus) 
             #else:
             #   A_, B_, C_, D_, E_, F_ = setup_pent_diag(nlayer,nwno,  c_plus_up, c_minus_up, 
             #                       c_plus_down, c_minus_down, b_top, b_surface, surf_reflect,
@@ -2241,11 +2269,11 @@ def get_thermal_3d(nlevel, wno,nwno, numg,numt,tlevel_3d, dtau_3d, w0_3d,cosb_3d
             L = nlayer+nlayer
             for w in range(nwno):
                 #coefficient of posive and negative exponential terms 
-                if tridiagonal==0:
-                    X = tri_diag_solve(L, A[:,w], B[:,w], C[:,w], D[:,w])
-                    #unmix the coefficients
-                    positive[:,w] = X[::2] + X[1::2] #Y1+Y2 in toon (table 3)
-                    negative[:,w] = X[::2] - X[1::2] #Y1-Y2 in toon (table 3)
+                #if tridiagonal==0:
+                X = tri_diag_solve(L, A[:,w], B[:,w], C[:,w], D[:,w])
+                #unmix the coefficients
+                positive[:,w] = X[::2] + X[1::2] #Y1+Y2 in toon (table 3)
+                negative[:,w] = X[::2] - X[1::2] #Y1-Y2 in toon (table 3)
                 #else:
                 #   X = pent_diag_solve(L, A_[:,w], B_[:,w], C_[:,w], D_[:,w], E_[:,w], F_[:,w])
                 #   positive[:,w] = exptrm_minus[:,w] * (X[::2] + X[1::2])

--- a/picaso/justdoit.py
+++ b/picaso/justdoit.py
@@ -1638,9 +1638,13 @@ class inputs():
                         fl+= 0.5*(flux_star[k-1] +flux_star[k])*abs((1.0/wno_star[k])-(1.0/wno_star[k-1]))
                 fine_flux_star[j] = fl
 
-            #where_are_NaNs = np.isnan(fine_flux_star)
-            
-            #fine_flux_star[where_are_NaNs] = 0   
+            #fix issue if there are zeros in certain bins 
+            mask = np.logical_or(np.isnan(fine_flux_star), fine_flux_star == 0)
+            if len(fine_wno_star[mask])>20:
+                print(f"Having to replace {len(fine_wno_star[mask])} zeros or nans in stellar spectra with interpolated values. It is advised you check this is correct and something has not gone wrong by plotting classname.inputs['star']['wno'] vs classname.inputs'star'['flux']")
+                non_zero_indices = np.where(~mask)
+                zero_nans = np.interp(fine_wno_star[mask], fine_wno_star[non_zero_indices], fine_flux_star[non_zero_indices])
+                fine_flux_star[mask] = zero_nans  
             
             opannection.unshifted_stellar_spec = fine_flux_star  
             bin_flux_star = fine_flux_star          
@@ -4023,7 +4027,7 @@ class inputs():
         all_out['cvz_locs'] = nstr_new
         all_out['flux']=flux_plus_final
         all_out['converged']=final_conv_flag
-        
+
         if save_all_profiles: all_out['all_profiles'] = all_profiles            
            
         if with_spec:

--- a/picaso/justdoit.py
+++ b/picaso/justdoit.py
@@ -120,7 +120,6 @@ def picaso(bundle,opacityclass, dimension = '1d',calculation='reflected',
     #USED in TOON (if being used)
     single_phase = inputs['approx']['rt_params']['toon']['single_phase']
     toon_coefficients = inputs['approx']['rt_params']['toon']['toon_coefficients']
-    tridiagonal = 0 
     multi_phase = inputs['approx']['rt_params']['toon']['multi_phase']
 
     #USED in SH (if being used)
@@ -932,7 +931,6 @@ def get_contribution(bundle, opacityclass, at_tau=1, dimension='1d'):
     single_phase = inputs['approx']['rt_params']['toon']['single_phase']
     #define delta eddington approximinations 
     delta_eddington = inputs['approx']['rt_params']['common']['delta_eddington']    
-    tridiagonal = 0 
     raman_approx = 2
 
     #parameters needed for the two term hg phase function. 
@@ -3908,7 +3906,7 @@ class inputs():
             bundle.premix_atmosphere(opacityclass, df = bundle.inputs['atmosphere']['profile'].loc[:,['pressure','temperature']])
             DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, \
                 W0_no_raman , surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase, \
-                frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , \
+                frac_a,frac_b,frac_c,constant_back,constant_forward, \
                 wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw,gweight,tweight =  calculate_atm(bundle, opacityclass)
             
             all_kzz= []
@@ -3923,7 +3921,7 @@ class inputs():
                 #flux_net_v_layer, flux_net_v, flux_plus_v, flux_minus_v , flux_net_ir_layer, flux_net_ir, flux_plus_ir, flux_minus_ir
                 flux_net_v_layer_full, flux_net_v_full, flux_plus_v_full, flux_minus_v_full , flux_net_ir_layer_full, flux_net_ir_full, flux_plus_ir_full, flux_minus_ir_full = get_fluxes(pressure, temp, delta_wno, bb , y2, tp, tmin, tmax, DTAU, TAU, W0, 
                 COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, 
-                ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , 
+                ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, 
                 wno,nwno,ng,nt,gweight,tweight, nlevel, ngauss, gauss_wts,True, True)#True for reflected, True for thermal
 
                 flux_net_ir_layer = flux_net_ir_layer_full[:]
@@ -4638,7 +4636,7 @@ def profile(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
         if cloudy == 1 :
             DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, \
             W0_no_raman , surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase, \
-            frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , \
+            frac_a,frac_b,frac_c,constant_back,constant_forward,  \
             wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw,gweight,tweight =  calculate_atm(bundle, opacityclass )
 
 
@@ -4692,7 +4690,7 @@ def profile(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
 
     DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, \
         W0_no_raman , surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase, \
-        frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , \
+        frac_a,frac_b,frac_c,constant_back,constant_forward, \
         wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw,gweight,tweight =  calculate_atm(bundle, opacityclass )
     
     ## begin bigger loop which gets opacities
@@ -4703,7 +4701,7 @@ def profile(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
                     rfaci, rfacv, nlevel, temp, pressure, p_table, t_table, 
                     grad, cp, tidal,tmin,tmax,dwni, bb , y2, tp, DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, 
                     DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, 
-                    ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , 
+                    ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, 
                     wno,nwno,ng,nt,gweight,tweight, 
                     ngauss, gauss_wts, save_profile, all_profiles)
         
@@ -4785,7 +4783,7 @@ def profile(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
 
         DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, \
         W0_no_raman , surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase, \
-        frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , \
+        frac_a,frac_b,frac_c,constant_back,constant_forward,  \
         wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw,gweight,tweight  =  calculate_atm(bundle, opacityclass)
 
         ert = 0.0 # avg temp change
@@ -5044,7 +5042,7 @@ def find_strat(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mult,
     bundle.premix_atmosphere(opacityclass, df = bundle.inputs['atmosphere']['profile'].loc[:,['pressure','temperature']])
 
     if cloudy == 1:
-        DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw,gweight,tweight  =  calculate_atm(bundle, opacityclass)
+        DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw,gweight,tweight  =  calculate_atm(bundle, opacityclass)
 
         metallicity = 10**(mh) #atmospheric metallicity relative to Solar
         mean_molecular_weight = np.mean(mmw) # atmospheric mean molecular weight
@@ -5066,11 +5064,11 @@ def find_strat(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mult,
     else:
         opd_now,w0_now,g0_now = 0,0,0
 
-    DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw,gweight,tweight  =  calculate_atm(bundle, opacityclass)
+    DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward,  wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw,gweight,tweight  =  calculate_atm(bundle, opacityclass)
     
     flux_net_v_layer_full, flux_net_v_full, flux_plus_v_full, flux_minus_v_full , flux_net_ir_layer_full, flux_net_ir_full, flux_plus_ir_full, flux_minus_ir_full = get_fluxes(pressure, temp, dwni, bb , y2, tp, tmin, tmax, DTAU, TAU, W0, 
             COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, 
-            ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , 
+            ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward,
             wno,nwno,ng,nt,gweight,tweight, nlevel, ngauss, gauss_wts, False, True) #false for reflected, true for thermal
 
       
@@ -5281,13 +5279,13 @@ def profile_deq(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
 
     DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, \
         W0_no_raman , surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase, \
-        frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , \
+        frac_a,frac_b,frac_c,constant_back,constant_forward, \
         wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw =  calculate_atm_deq(bundle, opacityclass,on_fly=on_fly,gases_fly=gases_fly)
     if self_consistent_kzz == True :
                 
         flux_net_v_layer_full, flux_net_v_full, flux_plus_v_full, flux_minus_v_full , flux_net_ir_layer_full, flux_net_ir_full, flux_plus_ir_full, flux_minus_ir_full = get_fluxes(pressure, temp, dwni, bb , y2, tp, tmin, tmax, DTAU, TAU, W0, 
         COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, 
-        ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , 
+        ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, 
         wno,nwno,ng,nt, gweight,tweight,nlevel, ngauss, gauss_wts,True, True)#True for reflected, True for thermal
 
         flux_net_ir_layer = flux_net_ir_layer_full[:]
@@ -5305,7 +5303,7 @@ def profile_deq(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
             COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, 
             W0_no_raman , surf_reflect, ubar0,ubar1,cos_theta, FOPI, 
             single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, 
-            tridiagonal , wno,nwno,ng,nt,gweight,tweight, ngauss, gauss_wts, save_profile, all_profiles)
+            wno,nwno,ng,nt,gweight,tweight, ngauss, gauss_wts, save_profile, all_profiles)
         '''
         if (temp <= min(opacityclass.cia_temps)).any():
             wh = np.where(temp <= min(opacityclass.cia_temps))
@@ -5398,14 +5396,14 @@ def profile_deq(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
         
         DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, \
         W0_no_raman , surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase, \
-        frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , \
+        frac_a,frac_b,frac_c,constant_back,constant_forward, \
         wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw =  calculate_atm_deq(bundle, opacityclass,on_fly=on_fly, gases_fly=gases_fly)
 
         if self_consistent_kzz == True :
                 
             flux_net_v_layer_full, flux_net_v_full, flux_plus_v_full, flux_minus_v_full , flux_net_ir_layer_full, flux_net_ir_full, flux_plus_ir_full, flux_minus_ir_full = get_fluxes(pressure, temp, dwni, bb , y2, tp, tmin, tmax, DTAU, TAU, W0, 
             COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, 
-            ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , 
+            ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward,  
             wno,nwno,ng,nt, gweight,tweight, nlevel, ngauss, gauss_wts,True, True)#True for reflected, True for thermal
 
             flux_net_ir_layer = flux_net_ir_layer_full[:]
@@ -5809,7 +5807,7 @@ def find_strat_deq(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mu
         qvmrs,qvmrs2 = 0,0
     
     if cloudy == 1:
-        DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw =  calculate_atm_deq(bundle, opacityclass,on_fly=on_fly, gases_fly=gases_fly)
+        DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw =  calculate_atm_deq(bundle, opacityclass,on_fly=on_fly, gases_fly=gases_fly)
         metallicity = 10**(0.0) #atmospheric metallicity relative to Solar
         mean_molecular_weight = np.mean(mmw) # atmospheric mean molecular weight
         # directory ='/Users/sagnickmukherjee/Documents/GitHub/virga/refr_new661'
@@ -5831,11 +5829,11 @@ def find_strat_deq(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mu
         opd_now,w0_now,g0_now = 0,0,0
     
     #bundle.premix_atmosphere_diseq(opacityclass, quench_levels=quench_levels, df = bundle.inputs['atmosphere']['profile'].loc[:,['pressure','temperature']])
-    DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw =  calculate_atm_deq(bundle, opacityclass,on_fly=on_fly, gases_fly=gases_fly)
+    DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw =  calculate_atm_deq(bundle, opacityclass,on_fly=on_fly, gases_fly=gases_fly)
     
     flux_net_v_layer_full, flux_net_v_full, flux_plus_v_full, flux_minus_v_full , flux_net_ir_layer_full, flux_net_ir_full, flux_plus_ir_full, flux_minus_ir_full = get_fluxes(pressure, temp, dwni, bb , y2, tp, tmin, tmax, DTAU, TAU, W0, 
             COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, 
-            ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, tridiagonal , 
+            ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, 
             wno,nwno,ng,nt,gweight,tweight, nlevel, ngauss, gauss_wts, False, True) #false for reflected, true for thermal
 
 

--- a/picaso/justdoit.py
+++ b/picaso/justdoit.py
@@ -1,7 +1,7 @@
 from .atmsetup import ATMSETUP
 from .fluxes import get_reflected_1d, get_reflected_3d , get_thermal_1d, get_thermal_3d, get_reflected_SH, get_transit_1d, get_thermal_SH
 
-from .fluxes import set_bb, tidal_flux, get_kzz
+from .fluxes import tidal_flux, get_kzz#set_bb, 
 from .climate import  calculate_atm_deq, did_grad_cp, convec, calculate_atm, t_start, growdown, growup, climate
 
 from .wavelength import get_cld_input_grid
@@ -1455,7 +1455,8 @@ class inputs():
         tmin = min_temp*(1-extension)
         tmax = max_temp*(1+extension)
 
-        bb , y2 , tp = set_bb(wno,delta_wno,nwno,ntmps,dt,tmin,tmax)
+        bb , y2 , tp = 0,0,0
+        #set_bb(wno,delta_wno,nwno,ntmps,dt,tmin,tmax)
 
         nofczns = self.inputs['climate']['nofczns']
         nstr= self.inputs['climate']['nstr']
@@ -3738,7 +3739,8 @@ class inputs():
         tmax = max_temp*(1+extension)
         ntmps = int((tmax-tmin)/dt)
         
-        bb , y2 , tp = set_bb(wno,delta_wno,nwno,ntmps,dt,tmin,tmax)
+        bb , y2 , tp = 0,0,0
+        #set_bb(wno,delta_wno,nwno,ntmps,dt,tmin,tmax)
 
         nofczns = self.inputs['climate']['nofczns']
         nstr= self.inputs['climate']['nstr']
@@ -4033,7 +4035,7 @@ class inputs():
             ntmps = int((tmax-tmin)/dt)
             
 
-            bb , y2 , tp = set_bb(wno,delta_wno,nwno,ntmps,dt,tmin,tmax)
+            #bb , y2 , tp = set_bb(wno,delta_wno,nwno,ntmps,dt,tmin,tmax)
 
         
 

--- a/picaso/justdoit.py
+++ b/picaso/justdoit.py
@@ -3794,6 +3794,10 @@ class inputs():
             fine_flux_star  = self.inputs['star']['flux']  # erg/s/cm^2
             FOPI = fine_flux_star * ((r_star/semi_major)**2)
 
+        #turn off reflected light permanently for all these runs if rfacv=0 
+        if rfacv==0:compute_reflected=False
+        else:compute_reflected=True
+
         all_profiles= []
         if save_all_profiles:
             save_profile = 1
@@ -3921,7 +3925,7 @@ class inputs():
                 flux_net_v_layer_full, flux_net_v_full, flux_plus_v_full, flux_minus_v_full , flux_net_ir_layer_full, flux_net_ir_full, flux_plus_ir_full, flux_minus_ir_full = get_fluxes(pressure, temp, delta_wno, bb , y2, tp, tmin, tmax, DTAU, TAU, W0, 
                 COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, 
                 ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, 
-                wno,nwno,ng,nt,gweight,tweight, nlevel, ngauss, gauss_wts,True, True)#True for reflected, True for thermal
+                wno,nwno,ng,nt,gweight,tweight, nlevel, ngauss, gauss_wts,compute_reflected, True)#True for reflected, True for thermal
 
                 flux_net_ir_layer = flux_net_ir_layer_full[:]
                 flux_plus_ir_attop = flux_plus_ir_full[0,:] 
@@ -4055,8 +4059,6 @@ class inputs():
             min_temp = min(opacityclass.temps)
             max_temp = max(opacityclass.temps)
 
-           
-            print(nwno)             
             # first calculate the BB grid
             ntmps = self.inputs['climate']['ntemp_bb_grid']
             dt = self.inputs['climate']['dt_bb_grid']
@@ -5151,6 +5153,11 @@ def profile_deq(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
         else Temperature array twice
     """
 
+    #permanently turn of ref light for cases where rfacv is zero 
+    #turn off reflected light permanently for all these runs if rfacv=0 
+    if rfacv==0:compute_reflected=False
+    else:compute_reflected=True
+
     # taudif is fixed to be 0 here since it is needed only for clouds
     taudif = 0.0
     taudif_tol = 0.1
@@ -5285,7 +5292,7 @@ def profile_deq(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
         flux_net_v_layer_full, flux_net_v_full, flux_plus_v_full, flux_minus_v_full , flux_net_ir_layer_full, flux_net_ir_full, flux_plus_ir_full, flux_minus_ir_full = get_fluxes(pressure, temp, dwni, bb , y2, tp, tmin, tmax, DTAU, TAU, W0, 
         COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, 
         ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, 
-        wno,nwno,ng,nt, gweight,tweight,nlevel, ngauss, gauss_wts,True, True)#True for reflected, True for thermal
+        wno,nwno,ng,nt, gweight,tweight,nlevel, ngauss, gauss_wts,compute_reflected, True)#True for reflected, True for thermal
 
         flux_net_ir_layer = flux_net_ir_layer_full[:]
         flux_plus_ir_attop = flux_plus_ir_full[0,:] 
@@ -5403,7 +5410,7 @@ def profile_deq(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
             flux_net_v_layer_full, flux_net_v_full, flux_plus_v_full, flux_minus_v_full , flux_net_ir_layer_full, flux_net_ir_full, flux_plus_ir_full, flux_minus_ir_full = get_fluxes(pressure, temp, dwni, bb , y2, tp, tmin, tmax, DTAU, TAU, W0, 
             COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, 
             ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward,  
-            wno,nwno,ng,nt, gweight,tweight, nlevel, ngauss, gauss_wts,True, True)#True for reflected, True for thermal
+            wno,nwno,ng,nt, gweight,tweight, nlevel, ngauss, gauss_wts,compute_reflected, True)#True for reflected if rfacv!=0, True for thermal
 
             flux_net_ir_layer = flux_net_ir_layer_full[:]
             flux_plus_ir_attop = flux_plus_ir_full[0,:] 

--- a/picaso/justdoit.py
+++ b/picaso/justdoit.py
@@ -1464,7 +1464,7 @@ class inputs():
         rfaci= self.inputs['climate']['rfaci']
         
         #turn off stellar radiation if user has run "setup_nostar() function"
-        if 'nostar' in self.inputs['star'].values():
+        if 'nostar' in self.inputs['star']['database']:
             rfacv=0.0 
             F0PI = np.zeros(nwno) #+ 1.0
         #otherwise assume that there is stellar irradiation 
@@ -3748,7 +3748,7 @@ class inputs():
         rfaci= self.inputs['climate']['rfaci']
         
         #turn off stellar radiation if user has run "setup_nostar() function"
-        if 'nostar' in self.inputs['star'].values():
+        if 'nostar' in self.inputs['star']['database']:
             rfacv=0.0 
             FOPI = np.zeros(nwno) + 1.0
         #otherwise assume that there is stellar irradiation 
@@ -3931,7 +3931,7 @@ class inputs():
             
             #Rerun star so that F0PI can now be on the 
             #661 grid 
-            if 'nostar' in self.inputs['star'].values():
+            if 'nostar' in self.inputs['star']['database']:
                 FOPI = np.zeros(opacityclass.nwno) + 1.0
             else:
                 T_star = self.inputs['star']['temp']

--- a/picaso/justdoit.py
+++ b/picaso/justdoit.py
@@ -5279,7 +5279,7 @@ def profile_deq(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
     DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, \
         W0_no_raman , surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase, \
         frac_a,frac_b,frac_c,constant_back,constant_forward, \
-        wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw =  calculate_atm_deq(bundle, opacityclass,on_fly=on_fly,gases_fly=gases_fly)
+        wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw,gweight,tweight =  calculate_atm_deq(bundle, opacityclass,on_fly=on_fly,gases_fly=gases_fly)
     if self_consistent_kzz == True :
                 
         flux_net_v_layer_full, flux_net_v_full, flux_plus_v_full, flux_minus_v_full , flux_net_ir_layer_full, flux_net_ir_full, flux_plus_ir_full, flux_minus_ir_full = get_fluxes(pressure, temp, dwni, bb , y2, tp, tmin, tmax, DTAU, TAU, W0, 
@@ -5396,7 +5396,7 @@ def profile_deq(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
         DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, \
         W0_no_raman , surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase, \
         frac_a,frac_b,frac_c,constant_back,constant_forward, \
-        wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw =  calculate_atm_deq(bundle, opacityclass,on_fly=on_fly, gases_fly=gases_fly)
+        wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw,gweight,tweight =  calculate_atm_deq(bundle, opacityclass,on_fly=on_fly, gases_fly=gases_fly)
 
         if self_consistent_kzz == True :
                 
@@ -5806,7 +5806,7 @@ def find_strat_deq(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mu
         qvmrs,qvmrs2 = 0,0
     
     if cloudy == 1:
-        DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw =  calculate_atm_deq(bundle, opacityclass,on_fly=on_fly, gases_fly=gases_fly)
+        DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw,gweight,tweight =  calculate_atm_deq(bundle, opacityclass,on_fly=on_fly, gases_fly=gases_fly)
         metallicity = 10**(0.0) #atmospheric metallicity relative to Solar
         mean_molecular_weight = np.mean(mmw) # atmospheric mean molecular weight
         # directory ='/Users/sagnickmukherjee/Documents/GitHub/virga/refr_new661'
@@ -5828,7 +5828,7 @@ def find_strat_deq(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mu
         opd_now,w0_now,g0_now = 0,0,0
     
     #bundle.premix_atmosphere_diseq(opacityclass, quench_levels=quench_levels, df = bundle.inputs['atmosphere']['profile'].loc[:,['pressure','temperature']])
-    DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw =  calculate_atm_deq(bundle, opacityclass,on_fly=on_fly, gases_fly=gases_fly)
+    DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw,gweight,tweight =  calculate_atm_deq(bundle, opacityclass,on_fly=on_fly, gases_fly=gases_fly)
     
     flux_net_v_layer_full, flux_net_v_full, flux_plus_v_full, flux_minus_v_full , flux_net_ir_layer_full, flux_net_ir_full, flux_plus_ir_full, flux_minus_ir_full = get_fluxes(pressure, temp, dwni, bb , y2, tp, tmin, tmax, DTAU, TAU, W0, 
             COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, 

--- a/picaso/justdoit.py
+++ b/picaso/justdoit.py
@@ -290,7 +290,7 @@ def picaso(bundle,opacityclass, dimension = '1d',calculation='reflected',
                     #                                    DTAU_OG[:,:,ig], W0_no_raman[:,:,ig], COSB_OG[:,:,ig], 
                     #                                    atm.level['pressure'],ubar1,
                     #                                    atm.surf_reflect, atm.hard_surface, tridiagonal)
-                    flux,lvl_fluxes  = get_thermal_1d_newclima(nlevel, wno,nwno,ng,nt,atm.level['temperature'],
+                    flux,lvl_fluxes  = get_thermal_1d(nlevel, wno,nwno,ng,nt,atm.level['temperature'],
                                                         DTAU_OG[:,:,ig], W0_no_raman[:,:,ig], COSB_OG[:,:,ig], 
                                                         atm.level['pressure'],ubar1,
                                                         atm.surf_reflect, atm.hard_surface,

--- a/picaso/justdoit.py
+++ b/picaso/justdoit.py
@@ -1490,7 +1490,7 @@ class inputs():
 
         Teff = self.inputs['planet']['T_eff']
         grav = 0.01*self.inputs['planet']['gravity'] # cgs to si
-        mh = float(self.inputs['climate']['mh'])
+        mh = float(self.inputs['climate']['mh']) if self.inputs['climate']['mh'] != None else 0.0
         sigma_sb = 0.56687e-4 # stefan-boltzmann constant
         
         col_den = 1e6*(pressure[1:] -pressure[:-1] ) / (grav/0.01) # cgs g/cm^2
@@ -3778,7 +3778,7 @@ class inputs():
 
         Teff = self.inputs['planet']['T_eff']
         grav = 0.01*self.inputs['planet']['gravity'] # cgs to si
-        mh = float(self.inputs['climate']['mh'])
+        mh = float(self.inputs['climate']['mh']) if self.inputs['climate']['mh'] != None else 0.0
         sigma_sb = 0.56687e-4 # stefan-boltzmann constant
         
         col_den = 1e6*(pressure[1:] -pressure[:-1] ) / (grav/0.01) # cgs g/cm^2

--- a/picaso/justdoit.py
+++ b/picaso/justdoit.py
@@ -1,6 +1,5 @@
 from .atmsetup import ATMSETUP
 from .fluxes import get_reflected_1d, get_reflected_3d , get_thermal_1d, get_thermal_3d, get_reflected_SH, get_transit_1d, get_thermal_SH
-from .fluxes import get_thermal_1d_newclima
 
 from .fluxes import tidal_flux, get_kzz#,set_bb_deprecate 
 from .climate import  calculate_atm_deq, did_grad_cp, convec, calculate_atm, t_start, growdown, growup, get_fluxes

--- a/picaso/justdoit.py
+++ b/picaso/justdoit.py
@@ -1475,7 +1475,7 @@ class inputs():
         self.inputs['climate']['mh'] = mh
         self.inputs['climate']['CtoO'] = CtoO
 
-    def old_run_climate_model(self, opacityclass):
+    def deprecate_run_climate_model(self, opacityclass):
         """
         Top Function to run the Climate Model
 
@@ -1555,7 +1555,6 @@ class inputs():
         convt=5.0
         x_max_mult=7.0
         
-        #print('NEB FIRST PROFILE RUN')
         final = False
         pressure, temperature, dtdp, profile_flag = profile(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
             TEMP1,pressure, F0PI, t_table, p_table, grad, cp, opacityclass, grav, 
@@ -1569,7 +1568,6 @@ class inputs():
         x_max_mult=7.0
 
 
-        #print('NEB SECOND PROFILE RUN')
         final = False
         pressure, temperature, dtdp, profile_flag = profile(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
                     temperature,pressure, F0PI, t_table, p_table, grad, cp, opacityclass, grav, 
@@ -1577,7 +1575,8 @@ class inputs():
         
         pressure, temp, dtdp, nstr_new, flux_plus_final =find_strat(mieff_dir, pressure, temperature, dtdp ,F0PI, nofczns,nstr,x_max_mult,
                              t_table, p_table, grad, cp, opacityclass, grav, 
-                             rfaci, rfacv, nlevel, tidal, tmin, tmax, delta_wno, bb , y2 , tp , cloudy, cld_species, mh,fsed)
+                             rfaci, rfacv, nlevel, tidal, tmin, tmax, delta_wno, bb , y2 , tp , cloudy, cld_species, mh,fsed,
+                             verbose=verbose)
 
         
         return pressure , temp, dtdp, nstr_new, flux_plus_final
@@ -3727,7 +3726,7 @@ class inputs():
 
     def climate(self, opacityclass, save_all_profiles = False, as_dict=True,with_spec=False,
         save_all_kzz = False, diseq_chem = False, self_consistent_kzz =False, kz = None, 
-        on_fly=False,gases_fly=None, chemeq_first=True):#,
+        on_fly=False,gases_fly=None, chemeq_first=True,verbose=True):#,
        
         """
         Top Function to run the Climate Model
@@ -3748,7 +3747,8 @@ class inputs():
             If you want to run MLT in convective zones and Moses in the radiative zones
         kz : array
             Kzz input array if user wants constant or whatever input profile (cgs)
-        
+        verbose : bool  
+            If True, triggers prints throughout code 
         """
         #save to user 
         all_out = {}
@@ -3848,7 +3848,10 @@ class inputs():
         
         if chemeq_first: pressure, temperature, dtdp, profile_flag, all_profiles,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop = profile(mieff_dir,it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
             TEMP1,pressure, FOPI, t_table, p_table, grad, cp, opacityclass, grav, 
-            rfaci, rfacv, nlevel, tidal, tmin, tmax, delta_wno, bb , y2 , tp, final , cloudy, cld_species,mh,fsed,flag_hack, save_profile,all_profiles,opd_cld_climate,g0_cld_climate,w0_cld_climate,first_call_ever=True)
+            rfaci, rfacv, nlevel, tidal, tmin, tmax, delta_wno, bb , y2 , tp, final , 
+            cloudy, cld_species,mh,fsed,flag_hack, save_profile,all_profiles,
+            opd_cld_climate,g0_cld_climate,w0_cld_climate,
+            first_call_ever=True, verbose=verbose)
 
         # second convergence call
         it_max= 7
@@ -3861,11 +3864,15 @@ class inputs():
         final = False
         if chemeq_first: pressure, temperature, dtdp, profile_flag, all_profiles,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop = profile(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
                     temperature,pressure, FOPI, t_table, p_table, grad, cp, opacityclass, grav, 
-                    rfaci, rfacv, nlevel, tidal, tmin, tmax, delta_wno, bb , y2 , tp, final, cloudy, cld_species, mh,fsed,flag_hack,save_profile,all_profiles,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop )   
+                    rfaci, rfacv, nlevel, tidal, tmin, tmax, delta_wno, bb , y2 , tp, final, cloudy, 
+                    cld_species, mh,fsed,flag_hack,save_profile,all_profiles,
+                    opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, 
+                    flux_plus_ir_attop, verbose=verbose )   
 
         if chemeq_first: pressure, temp, dtdp, nstr_new, flux_plus_final, df, all_profiles, opd_now,w0_now,g0_now =find_strat(mieff_dir, pressure, temperature, dtdp ,FOPI, nofczns,nstr,x_max_mult,
                              t_table, p_table, grad, cp, opacityclass, grav, 
-                             rfaci, rfacv, nlevel, tidal, tmin, tmax, delta_wno, bb , y2 , tp , cloudy, cld_species, mh,fsed, flag_hack, save_profile,all_profiles,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop)
+                             rfaci, rfacv, nlevel, tidal, tmin, tmax, delta_wno, bb , y2 , tp , cloudy, cld_species, mh,fsed, flag_hack, save_profile,all_profiles,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,
+                             verbose=verbose)
 
         
         if diseq_chem:
@@ -3884,20 +3891,20 @@ class inputs():
                 nstr[2] = 89
                 nstr[3],nstr[4],nstr[5] = 0,0,0
                 
-                print("2 conv Zones, so making small adjustments")
+                if verbose: print("2 conv Zones, so making small adjustments")
             elif (nstr[1] > 0) & (nstr[3] == 0):
                 if nstr[4] == 0:
                     nstr[1]+= del_zone #5#15
                 else:
                     nstr[1] += del_zone #5#15  
                     nstr[3], nstr[4] ,nstr[5] = 0,0,0#6#16
-                print("1 conv Zone, so making small adjustment")
+                if verbose: print("1 conv Zone, so making small adjustment")
             if nstr[1] >= nlevel -2 : # making sure we haven't pushed zones too deep
                 nstr[1] = nlevel -4
             if nstr[4] >= nlevel -2:
                 nstr[4] = nlevel -3
             
-            print("New NSTR status is ", nstr)
+            if verbose: print("New NSTR status is ", nstr)
 
             
 
@@ -3944,7 +3951,7 @@ class inputs():
             filename_db=os.path.join(__refdata__, 'climate_INPUTS/ck_cx_cont_opacities_661.db')
             
             if on_fly:
-                print("From now I will mix "+str(gases_fly)+" only on--the--fly")
+                if verbose: print("From now I will mix "+str(gases_fly)+" only on--the--fly")
                 #mhdeq and ctodeq will be auto by opannection
                 #NO Background, just CIA + whatever in gases_fly
                 #ck_db=os.path.join(__refdata__, 'climate_INPUTS/sonora_2020_feh'+mhdeq+'_co_'+CtoOdeq+'.data.196')
@@ -3964,7 +3971,6 @@ class inputs():
             if cloudy == 1:    
                 wv661 = 1e4/opacityclass.wno
                 opd_cld_climate,g0_cld_climate,w0_cld_climate = initiate_cld_matrices(opd_cld_climate,g0_cld_climate,w0_cld_climate,wv196,wv661)
-                print(np.shape(opd_cld_climate))
             
             #Rerun star so that F0PI can now be on the 
             #661 grid 
@@ -3996,7 +4002,7 @@ class inputs():
 
                 all_kzz = np.append(all_kzz, t_mix) # save kzz
 
-                print("Quench Levels are CO, CO2, NH3, HCN, PH3 ", quench_levels) # print quench levels
+                if verbose: print("Quench Levels are CO, CO2, NH3, HCN, PH3 ", quench_levels) # print quench levels
                 
                 final = False
                 #finall = False #### what is this thing?
@@ -4080,7 +4086,7 @@ class inputs():
             
             # diseq calculations start here actually
             
-            print("DOING DISEQ CALCULATIONS NOW")
+            if verbose: print("DOING DISEQ CALCULATIONS NOW")
             it_max= 7
             itmx= 5
             conv = 5.0
@@ -4094,12 +4100,17 @@ class inputs():
             
             pressure, temperature, dtdp, profile_flag, qvmrs, qvmrs2, all_profiles, all_kzz,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict  = profile_deq(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
             temp,pressure, FOPI, t_table, p_table, grad, cp, opacityclass, grav, 
-            rfaci, rfacv, nlevel, tidal, tmin, tmax, delta_wno, bb , y2 , tp, final , cloudy, cld_species,mh,fsed,flag_hack, quench_levels, kz, mmw,save_profile,all_profiles, self_consistent_kzz,save_kzz,all_kzz, opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict,on_fly=on_fly, gases_fly=gases_fly)
+            rfaci, rfacv, nlevel, tidal, tmin, tmax, delta_wno, bb , y2 , tp, final , 
+            cloudy, cld_species,mh,fsed,flag_hack, quench_levels, kz, mmw,save_profile,
+            all_profiles, self_consistent_kzz,save_kzz,all_kzz, opd_cld_climate,
+            g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,
+            photo_inputs_dict,
+            on_fly=on_fly, gases_fly=gases_fly, verbose=verbose)
             
-            print(photo_inputs_dict)
             pressure, temp, dtdp, nstr_new, flux_plus_final, qvmrs, qvmrs2, df, all_profiles, all_kzz,opd_now,g0_now,w0_now,photo_inputs_dict=find_strat_deq(mieff_dir, pressure, temperature, dtdp ,FOPI, nofczns,nstr,x_max_mult,
                             t_table, p_table, grad, cp, opacityclass, grav, 
-                            rfaci, rfacv, nlevel, tidal, tmin, tmax, delta_wno, bb , y2 , tp , cloudy, cld_species, mh,fsed, flag_hack, quench_levels,kz ,mmw, save_profile,all_profiles, self_consistent_kzz,save_kzz,all_kzz, opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict,on_fly=on_fly, gases_fly=gases_fly)
+                            rfaci, rfacv, nlevel, tidal, tmin, tmax, delta_wno, bb , y2 , tp , cloudy, cld_species, mh,fsed, flag_hack, quench_levels,kz ,mmw, save_profile,all_profiles, self_consistent_kzz,save_kzz,all_kzz, opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict,on_fly=on_fly, gases_fly=gases_fly,
+                             verbose=verbose)
             
                 
 
@@ -4704,7 +4715,8 @@ def profile(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
                     DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , surf_reflect, 
                     ubar0,ubar1,cos_theta, FOPI, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, 
                     wno,nwno,ng,nt,gweight,tweight, 
-                    ngauss, gauss_wts, save_profile, all_profiles)
+                    ngauss, gauss_wts, save_profile, all_profiles,
+                    verbose=verbose)
         
         #NEB stage delete after confirmation from SM
         #if (temp <= min(opacityclass.cia_temps)).any():
@@ -4814,7 +4826,7 @@ def profile(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
 
 def find_strat(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mult,
              t_table, p_table, grad, cp, opacityclass, grav, 
-             rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, cloudy, cld_species,mh,fsed,flag_hack, save_profile, all_profiles, opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop):
+             rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, cloudy, cld_species,mh,fsed,flag_hack, save_profile, all_profiles, opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,verbose=1):
     """
     Function iterating on the TP profile by calling tstart and changing opacities as well
     Parameters
@@ -4881,7 +4893,9 @@ def find_strat(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mult,
         Maximum allowed Temp in the profile
     dwni : array
         Spectral interval corrections (dimension= nwvno)
-       
+    verbose: int 
+        If 0 nothing gets printed
+        If 1 this prints everything out 
         
     Returns
     -------
@@ -4909,7 +4923,7 @@ def find_strat(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mult,
         ratio = dtdp[nstr[1]-1]/grad_x[nstr[1]-1]
 
         if ratio > 1.8 :
-            print("Move up two levels")
+            if verbose: print("Move up two levels")
             ngrow = 2
             nstr = growup( 1, nstr , ngrow)
         else :
@@ -4920,8 +4934,11 @@ def find_strat(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mult,
             raise ValueError( "Convection zone grew to Top of atmosphere, Need to Stop")
         
         pressure, temp, dtdp, profile_flag, all_profiles, opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop = profile(mieff_dir, it_max_strat, itmx_strat, conv_strat, convt_strat, nofczns,nstr,x_max_mult,
-            temp,pressure, FOPI, t_table, p_table, grad, cp, opacityclass, grav, 
-             rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, final, cloudy, cld_species, mh,fsed,flag_hack, save_profile, all_profiles, opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop)
+                            temp,pressure, FOPI, t_table, p_table, grad, cp, opacityclass, grav, 
+                             rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, final, 
+                             cloudy, cld_species, mh,fsed,flag_hack, save_profile, all_profiles, 
+                             opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, 
+                             flux_plus_ir_attop, verbose=verbose)
 
     # now for the 2nd convection zone
     dt_max = 0.0 #DTMAX
@@ -4940,9 +4957,9 @@ def find_strat(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mult,
         flag_final_convergence = 1
 
     if flag_final_convergence  == 0:
-        print(" convection zone status")
-        print(nstr[0],nstr[1],nstr[2],nstr[3],nstr[4],nstr[5])
-        print(nofczns)
+        if verbose: print(" convection zone status")
+        if verbose: print(nstr[0],nstr[1],nstr[2],nstr[3],nstr[4],nstr[5])
+        if verbose: print(nofczns)
 
         nofczns = 2
         nstr[4]= nstr[1]
@@ -4950,18 +4967,21 @@ def find_strat(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mult,
         nstr[1]= i_max
         nstr[2] = i_max
         nstr[3] = i_max #+ 1
-        print(nstr)
+        if verbose: print(nstr)
         if nstr[3] >= nstr[4] :
             #print(nstr[0],nstr[1],nstr[2],nstr[3],nstr[4],nstr[5])
             #print(nofczns)
             raise ValueError("Overlap happened !")
         pressure, temp, dtdp, profile_flag, all_profiles, opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop = profile(mieff_dir, it_max_strat, itmx_strat, conv_strat, convt_strat, nofczns,nstr,x_max_mult,
             temp,pressure, FOPI, t_table, p_table, grad, cp, opacityclass, grav, 
-             rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, final, cloudy, cld_species,mh, fsed,flag_hack,save_profile, all_profiles,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop)
+             rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, final, 
+             cloudy, cld_species,mh, fsed,flag_hack,save_profile, all_profiles,
+             opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, 
+             flux_plus_ir_attop, verbose=verbose)
 
         i_change = 1
         while i_change == 1 :
-            print("Grow Phase : Upper Zone")
+            if verbose: print("Grow Phase : Upper Zone")
             i_change = 0
 
             d1 = dtdp[nstr[1]-1]
@@ -4986,10 +5006,13 @@ def find_strat(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mult,
                         nstr[2] = nstr[5]
                         nstr[3] = 0
                         i_change = 1
-                print(nstr)
+                if verbose: print(nstr)
                 pressure, temp, dtdp, profile_flag, all_profiles,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop = profile(mieff_dir, it_max_strat, itmx_strat, conv_strat, convt_strat, nofczns,nstr,x_max_mult,
-            temp,pressure, FOPI, t_table, p_table, grad, cp, opacityclass, grav, 
-             rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, final, cloudy, cld_species, mh,fsed,flag_hack,save_profile, all_profiles,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop)
+                                temp,pressure, FOPI, t_table, p_table, grad, cp, opacityclass, grav, 
+                                 rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, final, 
+                                 cloudy, cld_species, mh,fsed,flag_hack,save_profile, all_profiles,
+                                 opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, 
+                                 flux_plus_ir_attop, verbose=verbose)
 
                 d1 = dtdp[nstr[1]-1]
                 d2 = dtdp[nstr[3]]
@@ -5006,10 +5029,13 @@ def find_strat(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mult,
                     nstr[2] = nstr[5]
                     nstr[3] = 0
                     i_change =1
-                print(nstr)
+                if verbose: print(nstr)
                 pressure, temp, dtdp, profile_flag, all_profiles,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop = profile(mieff_dir, it_max_strat, itmx_strat, conv_strat, convt_strat, nofczns,nstr,x_max_mult,
                     temp,pressure, FOPI, t_table, p_table, grad, cp, opacityclass, grav, 
-                    rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, final, cloudy, cld_species, mh,fsed,flag_hack,save_profile, all_profiles,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop)
+                    rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, final, 
+                    cloudy, cld_species, mh,fsed,flag_hack,save_profile, all_profiles,
+                    opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, 
+                    flux_plus_ir_attop, verbose=verbose)
             
 
             flag_final_convergence = 1
@@ -5022,18 +5048,21 @@ def find_strat(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mult,
     ip2 = -10
 
     final = True
-    print("final",nstr)
+    if verbose: print("final",nstr)
     pressure, temp, dtdp, profile_flag, all_profiles,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop = profile(mieff_dir, it_max_strat, itmx_strat, conv_strat, convt_strat, nofczns,nstr,x_max_mult,
                 temp,pressure, FOPI, t_table, p_table, grad, cp,opacityclass, grav, 
-                rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, final, cloudy, cld_species,mh,fsed,flag_hack,save_profile, all_profiles,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop)
+                rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, final, 
+                cloudy, cld_species,mh,fsed,flag_hack,save_profile, all_profiles,
+                opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, 
+                flux_plus_ir_attop, verbose=verbose)
 
     #    else :
     #        raise ValueError("Some problem here with goto 125")
         
     if profile_flag == 0:
-        print("ENDING WITHOUT CONVERGING")
+        if verbose: print("ENDING WITHOUT CONVERGING")
     elif profile_flag == 1:
-        print("YAY ! ENDING WITH CONVERGENCE")
+        if verbose: print("YAY ! ENDING WITH CONVERGENCE")
         
     bundle = inputs(calculation='brown')
     bundle.phase_angle(0)
@@ -5078,7 +5107,11 @@ def find_strat(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mult,
 
 def profile_deq(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
             temp,pressure,FOPI, t_table, p_table, grad, cp, opacityclass, grav, 
-             rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, final, cloudy, cld_species,mh,fsed,flag_hack,quench_levels,kz,mmw, save_profile, all_profiles,self_consistent_kzz,save_kzz,all_kzz, opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict=None,on_fly=False,gases_fly=None ):
+             rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, final, 
+             cloudy, cld_species,mh,fsed,flag_hack,quench_levels,kz,mmw, save_profile,
+              all_profiles,self_consistent_kzz,save_kzz,all_kzz, opd_cld_climate,
+              g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,
+              photo_inputs_dict=None,on_fly=False,gases_fly=None,verbose=True ):
     """
     Function iterating on the TP profile by calling tstart and changing opacities as well
     Parameters
@@ -5145,7 +5178,8 @@ def profile_deq(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
         Maximum allowed Temp in the profile
     dwni : array
         Spectral interval corrections (dimension= nwvno)   
-        
+    verbose : bool 
+        If True, prints out messages 
     Returns
     -------
     array 
@@ -5309,7 +5343,8 @@ def profile_deq(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
             COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, 
             W0_no_raman , surf_reflect, ubar0,ubar1,cos_theta, FOPI, 
             single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, 
-            wno,nwno,ng,nt,gweight,tweight, ngauss, gauss_wts, save_profile, all_profiles)
+            wno,nwno,ng,nt,gweight,tweight, ngauss, gauss_wts, save_profile, all_profiles,
+            verbose=verbose)
         '''
         if (temp <= min(opacityclass.cia_temps)).any():
             wh = np.where(temp <= min(opacityclass.cia_temps))
@@ -5397,7 +5432,7 @@ def profile_deq(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
             taudif = np.max(np.abs(diff))
             taudif_tol = 0.4*np.max(0.5*(opd_clmt+opd_prev_cld_step))
             
-            print("Max TAUCLD diff is", taudif, " Tau tolerance is ", taudif_tol)
+            if verbose: print("Max TAUCLD diff is", taudif, " Tau tolerance is ", taudif_tol)
 
         
         DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, \
@@ -5445,7 +5480,7 @@ def profile_deq(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
         ert = ert/(float(nlevel)*scalt)
         
         if ((iii > 0) & (ert < convt) & (taudif < taudif_tol)) :
-            print("Profile converged")
+            if verbose: print("Profile converged")
             conv_flag = 1
             if final == True :
                 itmx = 6
@@ -5499,7 +5534,7 @@ def profile_deq(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
             return pressure, temp , dtdp, conv_flag, qvmrs, qvmrs2, all_profiles, all_kzz, opd_cld_climate, g0_cld_climate, w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict
             
         
-        print("Big iteration is ",min(temp), iii)
+        if verbose: print("Big iteration is ",min(temp), iii)
     conv_flag = 0
     ## this is supposed to be useless so testing this
     '''
@@ -5553,15 +5588,15 @@ def profile_deq(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
             conv_flag = 1
     '''
     if conv_flag == 0:
-        print("Not converged")
+        if verbose: print("Not converged")
     else :
-        print("Profile converged")
+        if verbose: print("Profile converged")
     
     return pressure, temp , dtdp, conv_flag, qvmrs, qvmrs2, all_profiles, all_kzz, opd_cld_climate, g0_cld_climate, w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict
     
 def find_strat_deq(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mult,
              t_table, p_table, grad, cp, opacityclass, grav, 
-             rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, cloudy, cld_species,mh,fsed,flag_hack, quench_levels, kz,mmw, save_profile, all_profiles,self_consistent_kzz ,save_kzz,all_kzz, opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict=None,on_fly=False, gases_fly=None ):
+             rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, cloudy, cld_species,mh,fsed,flag_hack, quench_levels, kz,mmw, save_profile, all_profiles,self_consistent_kzz ,save_kzz,all_kzz, opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict=None,on_fly=False, gases_fly=None , verbose=1):
     """
     Function iterating on the TP profile by calling tstart and changing opacities as well
     Parameters
@@ -5628,6 +5663,9 @@ def find_strat_deq(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mu
         Maximum allowed Temp in the profile
     dwni : array
         Spectral interval corrections (dimension= nwvno)   
+    verbose : int 
+        If 1= prints out all output 
+        If 0= does not print anything out
         
     Returns
     -------
@@ -5655,7 +5693,7 @@ def find_strat_deq(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mu
         ratio = dtdp[nstr[1]-1]/grad_x[nstr[1]-1]
 
         if ratio > 1.8 :
-            print("Move up two levels")
+            if verbose: print("Move up two levels")
             ngrow = 2
             nstr = growup( 1, nstr , ngrow)
         else :
@@ -5666,7 +5704,7 @@ def find_strat_deq(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mu
             raise ValueError( "Convection zone grew to Top of atmosphere, Need to Stop")
         pressure, temp, dtdp, profile_flag, qvmrs, qvmrs2, all_profiles, all_kzz,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict = profile_deq(mieff_dir,it_max_strat, itmx_strat, conv_strat, convt_strat, nofczns,nstr,x_max_mult,\
             temp,pressure, FOPI, t_table, p_table, grad, cp, opacityclass, grav,rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, final, cloudy, cld_species, mh,fsed,flag_hack, quench_levels, kz, mmw, save_profile, all_profiles, self_consistent_kzz,save_kzz,all_kzz,opd_cld_climate,g0_cld_climate,\
-            w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict,on_fly=on_fly, gases_fly=gases_fly )
+            w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict,on_fly=on_fly, gases_fly=gases_fly , verbose=verbose)
 
     # now for the 2nd convection zone
     dt_max = 0.0 #DTMAX
@@ -5685,9 +5723,9 @@ def find_strat_deq(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mu
         flag_final_convergence = 1
 
     if flag_final_convergence  == 0:
-        print(" convection zone status")
-        print(nstr[0],nstr[1],nstr[2],nstr[3],nstr[4],nstr[5])
-        print(nofczns)
+        if verbose: print(" convection zone status")
+        if verbose: print(nstr[0],nstr[1],nstr[2],nstr[3],nstr[4],nstr[5])
+        if verbose: print(nofczns)
 
         nofczns = 2
         nstr[4]= nstr[1]
@@ -5695,18 +5733,23 @@ def find_strat_deq(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mu
         nstr[1]= i_max
         nstr[2] = i_max
         nstr[3] = i_max #+ 1
-        print(nstr)
+        if verbose: print(nstr)
         if nstr[3] >= nstr[4] :
             #print(nstr[0],nstr[1],nstr[2],nstr[3],nstr[4],nstr[5])
             #print(nofczns)
             raise ValueError("Overlap happened !")
         pressure, temp, dtdp, profile_flag, qvmrs, qvmrs2, all_profiles, all_kzz,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict = profile_deq(mieff_dir,it_max_strat, itmx_strat, conv_strat, convt_strat, nofczns,nstr,x_max_mult,\
             temp,pressure, FOPI, t_table, p_table, grad, cp, opacityclass, grav, \
-             rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, final, cloudy, cld_species,mh, fsed,flag_hack, quench_levels, kz , mmw,save_profile, all_profiles, self_consistent_kzz, save_kzz,all_kzz,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict,on_fly=on_fly, gases_fly=gases_fly )
+             rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, final, 
+             cloudy, cld_species,mh, fsed,flag_hack, quench_levels, kz , mmw,
+             save_profile, all_profiles, self_consistent_kzz, save_kzz,all_kzz,
+             opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, 
+             flux_plus_ir_attop,photo_inputs_dict,
+             on_fly=on_fly, gases_fly=gases_fly, verbose=verbose )
 
         i_change = 1
         while i_change == 1 :
-            print("Grow Phase : Upper Zone")
+            if verbose: print("Grow Phase : Upper Zone")
             i_change = 0
 
             d1 = dtdp[nstr[1]-1]
@@ -5731,10 +5774,10 @@ def find_strat_deq(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mu
                         nstr[2] = nstr[5]
                         nstr[3] = 0
                         i_change = 1
-                print(nstr)
+                if verbose: print(nstr)
                 pressure, temp, dtdp, profile_flag,qvmrs, qvmrs2, all_profiles, all_kzz,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict = profile_deq(mieff_dir,it_max_strat, itmx_strat, conv_strat, convt_strat, nofczns,nstr,x_max_mult,\
             temp,pressure, FOPI, t_table, p_table, grad, cp, opacityclass, grav, \
-             rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, final, cloudy, cld_species, mh,fsed,flag_hack, quench_levels, kz, mmw, save_profile, all_profiles,self_consistent_kzz,save_kzz,all_kzz,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict,on_fly=on_fly, gases_fly=gases_fly)
+             rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, final, cloudy, cld_species, mh,fsed,flag_hack, quench_levels, kz, mmw, save_profile, all_profiles,self_consistent_kzz,save_kzz,all_kzz,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict,on_fly=on_fly, gases_fly=gases_fly, verbose=verbose)
 
                 d1 = dtdp[nstr[1]-1]
                 d2 = dtdp[nstr[3]]
@@ -5751,9 +5794,9 @@ def find_strat_deq(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mu
                     nstr[2] = nstr[5]
                     nstr[3] = 0
                     i_change =1
-                print(nstr)
+                if verbose: print(nstr)
                 pressure, temp, dtdp, profile_flag, qvmrs, qvmrs2, all_profiles, all_kzz,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict = profile_deq(mieff_dir,it_max_strat, itmx_strat, conv_strat, convt_strat, nofczns,nstr,x_max_mult, \
-                                                        temp,pressure, FOPI, t_table, p_table, grad, cp, opacityclass, grav,rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, final, cloudy, cld_species, mh,fsed,flag_hack, quench_levels, kz, mmw,save_profile, all_profiles, self_consistent_kzz, save_kzz,all_kzz,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict,on_fly=on_fly, gases_fly=gases_fly)
+                                                        temp,pressure, FOPI, t_table, p_table, grad, cp, opacityclass, grav,rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, final, cloudy, cld_species, mh,fsed,flag_hack, quench_levels, kz, mmw,save_profile, all_profiles, self_consistent_kzz, save_kzz,all_kzz,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict,on_fly=on_fly, gases_fly=gases_fly, verbose=verbose)
             
 
             flag_final_convergence = 1
@@ -5766,18 +5809,18 @@ def find_strat_deq(mieff_dir, pressure, temp, dtdp , FOPI, nofczns,nstr,x_max_mu
     ip2 = -10
 
     final = True
-    print("final",nstr)
+    if verbose: print("final",nstr)
     pressure, temp, dtdp, profile_flag,qvmrs, qvmrs2, all_profiles, all_kzz,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict = profile_deq(mieff_dir,it_max_strat, itmx_strat, conv_strat, convt_strat, nofczns,nstr,x_max_mult,\
                 temp,pressure, FOPI, t_table, p_table, grad, cp,opacityclass, grav, \
-                rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, final, cloudy, cld_species,mh,fsed,flag_hack,quench_levels,kz, mmw,save_profile, all_profiles, self_consistent_kzz,save_kzz,all_kzz,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict,on_fly=on_fly, gases_fly=gases_fly)
+                rfaci, rfacv, nlevel, tidal, tmin, tmax, dwni, bb , y2 , tp, final, cloudy, cld_species,mh,fsed,flag_hack,quench_levels,kz, mmw,save_profile, all_profiles, self_consistent_kzz,save_kzz,all_kzz,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict,on_fly=on_fly, gases_fly=gases_fly, verbose=verbose)
 
     #    else :
     #        raise ValueError("Some problem here with goto 125")
         
     if profile_flag == 0:
-        print("ENDING WITHOUT CONVERGING")
+        if verbose: print("ENDING WITHOUT CONVERGING")
     elif profile_flag == 1:
-        print("YAY ! ENDING WITH CONVERGENCE")
+        if verbose: print("YAY ! ENDING WITH CONVERGENCE")
         
     bundle = inputs(calculation='brown')
     bundle.phase_angle(0)

--- a/picaso/justdoit.py
+++ b/picaso/justdoit.py
@@ -1,6 +1,5 @@
 from .atmsetup import ATMSETUP
 from .fluxes import get_reflected_1d, get_reflected_3d , get_thermal_1d, get_thermal_3d, get_reflected_SH, get_transit_1d, get_thermal_SH
-from .fluxes import get_reflected_1d_newclima
 
 from .fluxes import tidal_flux, get_kzz#,set_bb_deprecate 
 from .climate import  calculate_atm_deq, did_grad_cp, convec, calculate_atm, t_start, growdown, growup, get_fluxes
@@ -267,7 +266,7 @@ def picaso(bundle,opacityclass, dimension = '1d',calculation='reflected',
                                         b_top=b_top)
                                         #get_toa_intensity=1, get_lvl_flux=0)"""
                     
-                    xint,lvl_fluxes = get_reflected_1d_newclima(nlevel, wno,nwno,ng,nt,
+                    xint,lvl_fluxes = get_reflected_1d(nlevel, wno,nwno,ng,nt,
                                     DTAU[:,:,ig], TAU[:,:,ig], W0[:,:,ig], COSB[:,:,ig],
                                     GCOS2[:,:,ig],ftau_cld[:,:,ig],ftau_ray[:,:,ig],
                                     DTAU_OG[:,:,ig], TAU_OG[:,:,ig], W0_OG[:,:,ig], COSB_OG[:,:,ig],

--- a/picaso/justplotit.py
+++ b/picaso/justplotit.py
@@ -26,6 +26,7 @@ from scipy.stats import binned_statistic
 
 from .fluxes import blackbody, get_transit_1d
 from .opacity_factory import *
+from .climate import convec
 
 def mean_regrid(x, y, newx=None, R=None):
     """
@@ -2118,3 +2119,31 @@ def rt_heatmap(data,figure_kwargs={},cmap_kwargs={}):
     p.axis.major_label_text_font_size='12px'
     return p
 
+    
+def pt_adiabat(clima_out, input_class, plot=True):
+    """
+    Plot the PT profile with the adiabat 
+
+    Parameters
+    ----------
+    clima_out : dict
+        Full output from picaso 
+    input_class : justdoit.input
+        PICASO input class (e.g. the result of jdi.inputs()) 
+
+    Returns
+    -------
+    adiabat, dTdP, pressure 
+    """
+    layer_p = clima_out['spectrum_output']['full_output']['layer']['pressure']
+    
+    grad, cp = convec(clima_out['temperature'],clima_out['pressure'],
+                      input_class.inputs['climate']['t_table'], input_class.inputs['climate']['p_table'], 
+                      input_class.inputs['climate']['grad'], input_class.inputs['climate']['cp'])
+                      
+    plt.semilogy(clima_out['dtdp'], layer_p)
+    plt.semilogy(grad,layer_p) 
+    plt.ylim([1e2,1e-4]), 
+    plt.xlabel('dT/dP vs adiabat')
+    plt.ylabel('Pressure(bars)')
+    return cp, clima_out['dtdp'], layer_p

--- a/picaso/optics.py
+++ b/picaso/optics.py
@@ -770,8 +770,8 @@ class RetrieveCKs():
         gpts_wts = np.reshape(np.array(data.iloc[end_temps+1:2+end_temps+int(2*self.ngauss/3),0:3]
                  .astype(float)).ravel()[1:-1], (self.ngauss,2))
 
-        self.gauss_pts = [i[0] for i in gpts_wts]
-        self.gauss_wts = [i[1] for i in gpts_wts]
+        self.gauss_pts = np.array([i[0] for i in gpts_wts])
+        self.gauss_wts = np.array([i[1] for i in gpts_wts])
 
         if not deq:
             kappa = np.array(data.iloc[3+end_temps+int(2*self.ngauss/3):-2,0:3].astype(float)).ravel()
@@ -858,8 +858,8 @@ class RetrieveCKs():
                 gpts_wts = np.reshape(np.array(data.iloc[end_temps+1:2+end_temps+int(2*self.ngauss/3),0:3]
                  .astype(float)).ravel()[:-2], (self.ngauss,2))
                 
-                self.gauss_pts = [i[0] for i in gpts_wts]
-                self.gauss_wts = [i[1] for i in gpts_wts]
+                self.gauss_pts = np.array([i[0] for i in gpts_wts])
+                self.gauss_wts = np.array([i[1] for i in gpts_wts])
             
                 kappa = np.array(
                     data.iloc[3+end_temps+int(2*self.ngauss/3):-2,0:3]
@@ -1058,8 +1058,8 @@ class RetrieveCKs():
                 gpts_wts = np.reshape(np.array(data.iloc[end_temps+1:2+end_temps+int(2*self.ngauss/3),0:3]
                  .astype(float)).ravel()[1:-1], (self.ngauss,2))
                 
-                self.gauss_pts = [i[0] for i in gpts_wts]
-                self.gauss_wts = [i[1] for i in gpts_wts]
+                self.gauss_pts = np.array([i[0] for i in gpts_wts])
+                self.gauss_wts = np.array([i[1] for i in gpts_wts])
             
                 kappa = np.array(
                     data.iloc[3+end_temps+int(2*self.ngauss/3):-2,0:3]
@@ -1147,8 +1147,8 @@ class RetrieveCKs():
         gpts_wts = np.reshape(np.array(data.iloc[end_temps+1:2+end_temps+int(2*self.ngauss/3),0:3]
          .astype(float)).ravel()[2:], (self.ngauss,2))
 
-        self.gauss_pts = [i[0] for i in gpts_wts]
-        self.gauss_wts = [i[1] for i in gpts_wts]
+        self.gauss_pts = np.array([i[0] for i in gpts_wts])
+        self.gauss_wts = np.array([i[1] for i in gpts_wts])
         
         
         #finally add pressure/temperature scale to abundances
@@ -1507,7 +1507,7 @@ class RetrieveCKs():
         
         #now get associated pressures 
         #p_log_low =  np.array([p_log_grid[i] for i in p_low_ind])
-        return [p_low_ind, p_hi_ind, t_low_ind, t_hi_ind], t_interp,p_interp
+        return np.array([p_low_ind, p_hi_ind, t_low_ind, t_hi_ind]), t_interp,p_interp
             
     def get_pre_mix_ck_nearest(self,atmosphere):
         """
@@ -2255,7 +2255,7 @@ class RetrieveOpacities():
 
         #monochromatic opacity option forces number of gauss points to 1
         self.ngauss = 1
-        self.gauss_wts = [1]
+        self.gauss_wts = np.array([1])
 
         if location == 'local':
             #self.conn = sqlite3.connect(db_filename, detect_types=sqlite3.PARSE_DECLTYPES)

--- a/picaso/test.py
+++ b/picaso/test.py
@@ -10,7 +10,20 @@ import astropy.units as u
 
 __refdata__ = os.environ.get('picaso_refdata')
 
+def test_it_all(): 
+	#reflected 1d 
 
+	#thermal 1d 
+
+	#reflected 3d 
+
+	#thermal 3d 
+
+	#climate tests 
+
+	#transit 1d 
+	return 
+	
 def thermal_sh_test(single_phase = 'OTHG', output_dir = None, 
 	phase=True, method="toon", stream=2, toon_coefficients="quadrature", delta_eddington=True,
 	disort_data=False, phangle=0, tau=0.2):


### PR DESCRIPTION
Fixes: 

1. Numerical instabilities encountered on some machines (presents itself as a NaN in the net flux vector) 
2. Array is singular encountered on some machines (presents itself when code tries to open detached convective zone) 

Adds: 

1. adds flag for convection as `out['converged']` not yet added to a tutorial 
2. verbose feature to turn off print statements throughout climate code
3. changes to calculate_atm functions to ensure that gweights and tweights are incorporated (you will see new I/Os to carry those through get_fluxes)
5. unifies all reflected and thermal 1d's 
6. adds adiabat plot and return to justplotit and added to exoplanet climate tutorial 
7. turns off reflected light when it isnt being used (when rfacv=0) 
8. fixes typos in climate tutorials 
9. deprecates triangular variable throughout the code since it is no longer being used 
10. enables users to run `approx(get_lvl_fluxes=True)` for any forward run to get level fluxes which now appears in `out['full_output']['level']` (this should probably go into a tutorial to show people how to use it) 

Keeps: 

1. oddity with step_max which we may have to fix. however we now understand the behavior as compared to the fortran (see figure) 