### PR TITLE
Add the option to save all temperature profiles in a climate run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.swo
 *.csv
 *.npy
+*.h5
 
 # Jupyter Notebooks
 .ipynb_checkpoints

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,9 @@
 
 History
 -------
+3.2 (2024-7-8)
+~~~~~~~~~~~~~~
+* Disequilibrium climate modeling
 
 3.1 (2023-3-23)
 ~~~~~~~~~~~~~~~

--- a/picaso/climate.py
+++ b/picaso/climate.py
@@ -327,7 +327,7 @@ def lu_backsubs(a, n, ntot, indx, b):
     return b
 
 # @logger.catch # Add this to track errors
-@jit(nopython=True, cache=True)
+@jit(nopython=True,cache=True)
 def t_start(nofczns,nstr,it_max,conv,x_max_mult, 
             rfaci, rfacv, nlevel, temp, pressure, p_table, t_table, 
             grad, cp, tidal, tmin,tmax, dwni , bb , y2, tp, DTAU, TAU, W0, COSB, 
@@ -971,7 +971,7 @@ def t_start(nofczns,nstr,it_max,conv,x_max_mult,
         if verbose: print("Iteration number ", its,", min , max temp ", min(temp),max(temp), ", flux balance ", flux_net[0]/abs(tidal[0]))
 
         if save_profile == 1:
-            all_profiles = np.append(all_profiles,temp_old)
+            all_profiles = np.vstack((all_profiles, temp_old.reshape((1,len(temp_old)))))
         if flag_converge == 2 : # converged
             # calculate  lapse rate
             dtdp=np.zeros(shape=(nlevel-1))

--- a/picaso/io_utils.py
+++ b/picaso/io_utils.py
@@ -2,6 +2,7 @@ import os
 import json 
 import pandas as pd
 import warnings 
+import h5py
 
 def read_json(filename, **kwargs):
     """
@@ -58,3 +59,16 @@ def read_hdf(filename, requires, raise_except=False, **kwargs):
     else: 
         d = pd.read_hdf(filename, hdf_name['table'].values[0])
     return d
+
+def write_all_profiles(save_all_profiles, all_profiles):
+    """
+    Saves all T(P) profiles to the file in "save_all_profiles"
+    """
+    if isinstance(save_all_profiles, str):
+        profiles_file = h5py.File(save_all_profiles, 'w')
+        gp = profiles_file.create_group("all_profiles")
+        num_digits = len(str(len(all_profiles)))
+        for (i, profile_to_save) in enumerate(all_profiles):
+            i_str = str(i).zfill(num_digits)
+            gp.create_dataset(f"pt_{i_str}", data=profile_to_save)
+        profiles_file.close()

--- a/picaso/justdoit.py
+++ b/picaso/justdoit.py
@@ -42,7 +42,7 @@ from joblib import Parallel, delayed, cpu_count
 # #testing error tracker
 # from loguru import logger 
 __refdata__ = os.environ.get('picaso_refdata')
-__version__ = 3.2
+__version__ = 3.2.1
 
 
 if not os.path.exists(__refdata__): 

--- a/picaso/justdoit.py
+++ b/picaso/justdoit.py
@@ -42,7 +42,7 @@ from joblib import Parallel, delayed, cpu_count
 # #testing error tracker
 # from loguru import logger 
 __refdata__ = os.environ.get('picaso_refdata')
-__version__ = 3.2.1
+__version__ = '3.2.2'
 
 
 if not os.path.exists(__refdata__): 
@@ -50,7 +50,7 @@ if not os.path.exists(__refdata__):
 else: 
     ref_v = json.load(open(os.path.join(__refdata__,'config.json'))).get('version',2.3)
     
-    if __version__ > ref_v: 
+    if __version__ != str(ref_v): 
         warnings.warn(f"Your code version is {__version__} but your reference data version is {ref_v}. For some functionality you may experience Keyword errors. Please download the newest ref version or update your code: https://github.com/natashabatalha/picaso/tree/master/reference")
 
 

--- a/picaso/justdoit.py
+++ b/picaso/justdoit.py
@@ -3725,11 +3725,11 @@ class inputs():
         if rfacv==0:compute_reflected=False
         else:compute_reflected=True
 
-        all_profiles= []
         save_profile = bool(save_all_profiles)
 
         TEMP1 = self.inputs['climate']['guess_temp']
-        all_profiles=np.append(all_profiles,TEMP1)
+        all_profiles = np.empty((1,len(TEMP1)))
+        all_profiles[0,:] = TEMP1
         pressure = self.inputs['climate']['pressure']
         t_table = self.inputs['climate']['t_table']
         p_table = self.inputs['climate']['p_table']
@@ -4590,7 +4590,7 @@ def profile(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
             temp[j1]= exp(log(temp[j1-1]) + grad_x*(log(pressure[j1]) - log(pressure[j1-1])))
     
     temp_old= np.copy(temp)
-
+    
 
     
     bundle = inputs(calculation='brown')
@@ -4600,7 +4600,8 @@ def profile(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
     
     bundle.premix_atmosphere(opacityclass, df = bundle.inputs['atmosphere']['profile'].loc[:,['pressure','temperature']])
     if save_profile == 1:
-            all_profiles = np.append(all_profiles,temp_old)
+        all_profiles = np.vstack((all_profiles, temp_old.reshape((1,len(temp_old)))))
+        
     
     if first_call_ever == False:
         if cloudy == 1 :
@@ -4665,7 +4666,6 @@ def profile(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
     
     ## begin bigger loop which gets opacities
     for iii in range(itmx):
-        
         temp, dtdp, flag_converge, flux_net_ir_layer, flux_plus_ir_attop, all_profiles = t_start(
                     nofczns,nstr,it_max,conv,x_max_mult, 
                     rfaci, rfacv, nlevel, temp, pressure, p_table, t_table, 

--- a/picaso/justdoit.py
+++ b/picaso/justdoit.py
@@ -11,7 +11,7 @@ from .justplotit import numba_cumsum, find_nearest_2d, mean_regrid
 from .deq_chem import quench_level,initiate_cld_matrices
 from .build_3d_input import regrid_xarray
 from .photochem import run_photochem
-
+from .io_utils import write_all_profiles
 
 from virga import justdoit as vj
 from scipy.interpolate import UnivariateSpline, interp1d
@@ -3951,6 +3951,7 @@ class inputs():
         TEMP1 = self.inputs['climate']['guess_temp']
         all_profiles = np.empty((1,len(TEMP1)))
         all_profiles[0,:] = TEMP1
+        write_all_profiles(save_all_profiles, all_profiles)
         pressure = self.inputs['climate']['pressure']
         t_table = self.inputs['climate']['t_table']
         p_table = self.inputs['climate']['p_table']
@@ -3998,6 +3999,7 @@ class inputs():
             cloudy, cld_species,mh,fsed,flag_hack, save_profile,all_profiles,
             opd_cld_climate,g0_cld_climate,w0_cld_climate,
             first_call_ever=True, verbose=verbose)
+        write_all_profiles(save_all_profiles, all_profiles)
 
         # second convergence call
         it_max= 7
@@ -4014,12 +4016,14 @@ class inputs():
                     cld_species, mh,fsed,flag_hack,save_profile,all_profiles,
                     opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, 
                     flux_plus_ir_attop, verbose=verbose )   
+        write_all_profiles(save_all_profiles, all_profiles)
 
         if chemeq_first: 
             pressure, temp, dtdp, nstr_new, flux_plus_final, df, all_profiles, cld_out, final_conv_flag=find_strat(mieff_dir, pressure, temperature, dtdp ,FOPI, nofczns,nstr,x_max_mult,
                              t_table, p_table, grad, cp, opacityclass, grav, 
                              rfaci, rfacv, nlevel, tidal, tmin, tmax, delta_wno, bb , y2 , tp , cloudy, cld_species, mh,fsed, flag_hack, save_profile,all_profiles,opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,
                              verbose=verbose)
+            write_all_profiles(save_all_profiles, all_profiles)
             if cloudy == 1:
                 opd_now,w0_now,g0_now = cld_out['opd_per_layer'],cld_out['single_scattering'],cld_out['asymmetry']
             else:
@@ -4251,16 +4255,17 @@ class inputs():
                 pressure, temperature, dtdp, profile_flag, qvmrs, qvmrs2, all_profiles, all_kzz,opd_cld_climate,g0_cld_climate,w0_cld_climate,cld_out,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict,_  = profile_deq(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
                 temp,pressure, FOPI, t_table, p_table, grad, cp, opacityclass, grav, 
                 rfaci, rfacv, nlevel, tidal, tmin, tmax, delta_wno, bb , y2 , tp, final , 
-            cloudy, cld_species,mh,fsed,flag_hack, quench_levels, kz, mmw,save_profile,
-            all_profiles, self_consistent_kzz,save_kzz,all_kzz, opd_cld_climate,
-            g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,
-            photo_inputs_dict,
-            on_fly=on_fly, gases_fly=gases_fly, verbose=verbose)
+                cloudy, cld_species,mh,fsed,flag_hack, quench_levels, kz, mmw,save_profile,
+                all_profiles, self_consistent_kzz,save_kzz,all_kzz, opd_cld_climate,
+                g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,
+                photo_inputs_dict,
+                on_fly=on_fly, gases_fly=gases_fly, verbose=verbose)
                 
                 pressure, temp, dtdp, nstr_new, flux_plus_final, qvmrs, qvmrs2, df, all_profiles, all_kzz,cld_out,photo_inputs_dict,final_conv_flag=find_strat_deq(mieff_dir, pressure, temperature, dtdp ,FOPI, nofczns,nstr,x_max_mult,
                                 t_table, p_table, grad, cp, opacityclass, grav, 
                                 rfaci, rfacv, nlevel, tidal, tmin, tmax, delta_wno, bb , y2 , tp , cloudy, cld_species, mh,fsed, flag_hack, quench_levels,kz ,mmw, save_profile,all_profiles, self_consistent_kzz,save_kzz,all_kzz, opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict,on_fly=on_fly, gases_fly=gases_fly,
                              verbose=verbose)
+                write_all_profiles(save_all_profiles, all_profiles)
                 if cloudy == 1:
                     opd_now,w0_now,g0_now = cld_out['opd_per_layer'],cld_out['single_scattering'],cld_out['asymmetry']
                 else:
@@ -4271,6 +4276,7 @@ class inputs():
                 pressure, temperature, dtdp, profile_flag, qvmrs, qvmrs2, all_profiles, all_kzz,opd_cld_climate,g0_cld_climate,w0_cld_climate,cld_out,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict, df  = profile_deq(mieff_dir, it_max, itmx, conv, convt, nofczns,nstr,x_max_mult,
                 temp,pressure, FOPI, t_table, p_table, grad, cp, opacityclass, grav, 
                 rfaci, rfacv, nlevel, tidal, tmin, tmax, delta_wno, bb , y2 , tp, final , cloudy, cld_species,mh,fsed,flag_hack, quench_levels, kz, mmw,save_profile,all_profiles, self_consistent_kzz,save_kzz,all_kzz, opd_cld_climate,g0_cld_climate,w0_cld_climate,flux_net_ir_layer, flux_plus_ir_attop,photo_inputs_dict,on_fly=on_fly, gases_fly=gases_fly)
+                write_all_profiles(save_all_profiles, all_profiles)
                 nstr_new = nstr.copy()
                 flux_plus_final = flux_plus_ir_attop.copy()
                 temp=temperature.copy()
@@ -4308,16 +4314,7 @@ class inputs():
             df_cld = vj.picaso_format(opd_now, w0_now, g0_now, pressure = cld_out['pressure'], wavenumber=1e4/cld_out['wave'])
             all_out['cld_output_picaso'] = df_cld
             all_out['virga_output'] = cld_out
-        if isinstance(save_all_profiles, str):
-            if verbose:
-                print(f"Saving all T(P) profiles to {save_all_profiles}")
-            profiles_file = h5py.File(save_all_profiles, 'w')
-            gp = profiles_file.create_group("all_profiles")
-            num_digits = len(str(len(all_profiles)))
-            for (i, profile_to_save) in enumerate(all_profiles):
-                i_str = str(i).zfill(num_digits)
-                gp.create_dataset(f"pt_{i_str}", data=profile_to_save)
-            profiles_file.close()
+        write_all_profiles(save_all_profiles, all_profiles)
         if as_dict: 
             return all_out
         else: 

--- a/picaso/justplotit.py
+++ b/picaso/justplotit.py
@@ -1927,12 +1927,12 @@ def animate_convergence(clima_out, picaso_bundle, opacity, calculation='thermal'
                 np.copy(clima_out['all_profiles']))
     
     nlevel = len(t_eq)
-    mols_to_plot = {i:np.zeros(len(all_profiles_eq)) for i in molecules}
-    spec = np.zeros(shape =(int(len(all_profiles_eq)/nlevel),opacity.nwno))
+    nstep = all_profiles_eq.shape[0]
+    mols_to_plot = {i:np.zeros(all_profiles_eq.size) for i in molecules}
+    spec = np.zeros(shape =(nstep,opacity.nwno))
     
-    for i in range(int(len(all_profiles_eq)/nlevel)):
-        
-        picaso_bundle.add_pt(all_profiles_eq[i*nlevel:(i+1)*nlevel], 
+    for i in range(nstep):
+        picaso_bundle.add_pt(all_profiles_eq[i], 
                              p_eq)
 
         picaso_bundle.premix_atmosphere(opacity,picaso_bundle.inputs['atmosphere']['profile'])
@@ -1963,7 +1963,7 @@ def animate_convergence(clima_out, picaso_bundle, opacity, calculation='thermal'
             # set the width ratios between the columns
             "width_ratios": [1,1,0.1,1,1,0.1,1,1]})
 
-    temp = all_profiles_eq[0*nlevel:(0+1)*nlevel]
+    temp = all_profiles_eq[0]
     lines = {}
     for imol,col in zip(molecules,Colorblind8):
         lines[imol], = ax['B'].loglog(mols_to_plot[imol][0:nlevel], p_eq,linewidth=3,color=col, label=imol)
@@ -2007,7 +2007,7 @@ def animate_convergence(clima_out, picaso_bundle, opacity, calculation='thermal'
         return lines
     
     def animate(i):                       
-        lines['temp'].set_xdata(all_profiles_eq[i*nlevel:(i+1)*nlevel])
+        lines['temp'].set_xdata(all_profiles_eq[i])
         
         for imol in molecules:
             lines[imol].set_xdata(mols_to_plot[imol][i*nlevel:(i+1)*nlevel])
@@ -2015,7 +2015,7 @@ def animate_convergence(clima_out, picaso_bundle, opacity, calculation='thermal'
         lines['spec'].set_ydata(spec[i,:][wh])
         return lines
 
-    ani = animation.FuncAnimation(fig, animate, frames=int(len(all_profiles_eq)/nlevel),init_func=init,interval=50, blit=False)
+    ani = animation.FuncAnimation(fig, animate, frames=nstep,init_func=init,interval=50, blit=False)
     plt.close()
     return ani
 

--- a/reference/config.json
+++ b/reference/config.json
@@ -1,5 +1,5 @@
 {
-	"version":3.2.1,
+	"version":"3.2.2",
 	"calculation":"spectrum_only",
 	"phase":0,
 	"planet":{

--- a/reference/config.json
+++ b/reference/config.json
@@ -1,5 +1,5 @@
 {
-	"version":3.2,
+	"version":3.2.1,
 	"calculation":"spectrum_only",
 	"phase":0,
 	"planet":{

--- a/reference/version.md
+++ b/reference/version.md
@@ -1,4 +1,8 @@
-Version 3.1 (current beta)
+Version 3.2
+-----------
+- Disequilibrium Climate (Mukherjee et al. 2024) Elf-OWL models
+
+Version 3.1 
 --------------------------
 - Spherical harmonics with reflected light (Rooney et al. 2023a)
 - Spherical harmonics with thermal emission (Rooney et al. 2023b) 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ except ImportError:
 # to this sample package.
 setup(
     name='picaso', 
-    version = '3.2.1',
+    version = '3.2.2',
     description = 'planetary intesity code for atmospheric scattering observations',
     long_description = 'README.md',
     author = 'Natasha E. Batalha',

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ except ImportError:
 # to this sample package.
 setup(
     name='picaso', 
-    version = '3.2',
+    version = '3.2.1',
     description = 'planetary intesity code for atmospheric scattering observations',
     long_description = 'README.md',
     author = 'Natasha E. Batalha',


### PR DESCRIPTION
Closes #213.
- Currently demonstrates the feature in the 12a notebook, I can move this to somewhere else in docs. The only change other than the feature demo is I'm using a relative path to `picaso/data/...` on my machine; I could change this back but am not sure how to make the path work as it was. Is there a project convention to make paths starting with /data work, such as having /path/to/picaso in sys.path?
- Previously, `all_profiles` flattened the array of temperature profiles so that it was a 1D array of length (niter * npoints,). Changed this to be a 2D array (niter, npoints) and changed `append` calls to `vstack` to accommodate this. This means we can read the temperature profile at each iteration from the HDF5 file without needing to calculate indices for where each one starts.
