### PR TITLE
Adding functionality for deq+on_fly mixing, and level flux calculations outside of climate

### DIFF
--- a/picaso/climate.py
+++ b/picaso/climate.py
@@ -1402,7 +1402,7 @@ def calculate_atm(bundle, opacityclass):
     return DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman , atm.surf_reflect, ubar0,ubar1,cos_theta, single_phase,multi_phase,frac_a,frac_b,frac_c,constant_back,constant_forward, wno,nwno,ng,nt, nlevel, ngauss, gauss_wts, mmw,gweight,tweight
 
 
-def calculate_atm_deq(bundle, opacityclass,on_fly=False,gases_fly=None):
+def calculate_atm_deq(bundle, opacityclass, on_fly=False, gases_fly=None):
 
     inputs = bundle.inputs
 
@@ -1513,11 +1513,8 @@ def calculate_atm_deq(bundle, opacityclass,on_fly=False,gases_fly=None):
     nlevel = atm.c.nlevel
     nlayer = atm.c.nlayer
     
-    if on_fly == False:
-        opacityclass.get_opacities_deq(bundle,atm)
-    else:
-        opacityclass.get_opacities_deq_onfly(bundle,atm,gases_fly=gases_fly)
-    
+    opacityclass.get_opacities(atm)
+
     DTAU, TAU, W0, COSB,ftau_cld, ftau_ray,GCOS2, DTAU_OG, TAU_OG, W0_OG, COSB_OG, W0_no_raman, f_deltaM= compute_opacity(
             atm, opacityclass, ngauss=ngauss, stream=stream, delta_eddington=delta_eddington,test_mode=test_mode,raman=raman_approx,
             full_output=False, plot_opacity=False)

--- a/picaso/disco.py
+++ b/picaso/disco.py
@@ -115,7 +115,7 @@ def get_angles_3d(num_gangle, num_tangle):
     return gangle,gweight,tangle,tweight
 
 @jit(nopython=True, cache=True)
-def compress_disco( nwno, cos_theta, xint_at_top, gweight, tweight,F0PI): 
+def compress_disco(nwno, cos_theta, xint_at_top, gweight, tweight, F0PI): 
     """
     Last step in albedo code. Integrates over phase angle based on the 
     Gaussian-Chebychev weights in geometry.json 
@@ -145,7 +145,8 @@ def compress_disco( nwno, cos_theta, xint_at_top, gweight, tweight,F0PI):
     for ig in range(ng): 
         for it in range(nt): 
             albedo = albedo + xint_at_top[ig,it,:] * gweight[ig] * tweight[it]
-    albedo = sym_fac * 0.5 * albedo /F0PI * (cos_theta + 1.0)
+            
+    albedo = sym_fac * 0.5 * albedo / F0PI * (cos_theta + 1.0)
     return albedo
 
 @jit(nopython=True, cache=True)

--- a/picaso/disco.py
+++ b/picaso/disco.py
@@ -115,7 +115,7 @@ def get_angles_3d(num_gangle, num_tangle):
     return gangle,gweight,tangle,tweight
 
 @jit(nopython=True, cache=True)
-def compress_disco(nwno, cos_theta, xint_at_top, gweight, tweight, F0PI): 
+def compress_disco( nwno, cos_theta, xint_at_top, gweight, tweight,F0PI): 
     """
     Last step in albedo code. Integrates over phase angle based on the 
     Gaussian-Chebychev weights in geometry.json 
@@ -145,8 +145,7 @@ def compress_disco(nwno, cos_theta, xint_at_top, gweight, tweight, F0PI):
     for ig in range(ng): 
         for it in range(nt): 
             albedo = albedo + xint_at_top[ig,it,:] * gweight[ig] * tweight[it]
-            
-    albedo = sym_fac * 0.5 * albedo / F0PI * (cos_theta + 1.0)
+    albedo = sym_fac * 0.5 * albedo /F0PI * (cos_theta + 1.0)
     return albedo
 
 @jit(nopython=True, cache=True)

--- a/picaso/fluxes.py
+++ b/picaso/fluxes.py
@@ -1752,7 +1752,7 @@ def get_thermal_1d(nlevel, wno,nwno, numg,numt,tlevel, dtau, w0,cosb,plevel, uba
     if calc_type == 0: 
         all_b = blackbody(tlevel, 1/wno) #returns nlevel by nwave   
     elif calc_type==1:
-        all_b = blackbody_integrated(tlevel, wno, dwno)
+        all_b = blackbody_integrated(tlevel, wno, dwno)    
 
     b0 = all_b[0:-1,:]
     b1 = (all_b[1:,:] - b0) / dtau # eqn 26 toon 89

--- a/picaso/justdoit.py
+++ b/picaso/justdoit.py
@@ -1674,6 +1674,7 @@ class inputs():
             bin_flux_star = opannection.unshifted_stellar_spec
 
         elif ('climate' in self.inputs['calculation'] or (get_lvl_flux)):
+            """
             #stellar flux of star 
             #print(len(wno_planet),len(flux_star[0:-1]),len(flux_star[1:]))
             # np.diff(1/wno_star) is wavelength window in cm.
@@ -1706,56 +1707,35 @@ class inputs():
                 zero_nans = np.interp(fine_wno_star[mask], fine_wno_star[non_zero_indices], fine_flux_star[non_zero_indices])
                 fine_flux_star[mask] = zero_nans  
             """
-            # Initialize output arrays
-            fine_flux_star = np.zeros(len(wno_planet))
-            fine_wno_star = wno_planet
 
-            # Integrate energy over bins
-            for j in range(len(wno_planet)-1):
-                fl = 0
-                for k in range(1, len(wno_star)):
-                    if (wno_star[k] > wno_planet[j]) and (wno_star[k] < wno_planet[j+1]):
-                        fl += 0.5 * (flux_star[k-1] + flux_star[k]) * abs((1.0 / wno_star[k]) - (1.0 / wno_star[k-1]))
-                fine_flux_star[j] = fl
+            # Ensure valid values for interpolation
+            mask_valid = flux_star > 1e-30  
+            if not np.all(mask_valid):
+                wno_star, flux_star = wno_star[mask_valid], flux_star[mask_valid]
 
-            # Interpolate missing values in log-space
-            log_wno_star = np.log10(wno_star)
-            log_flux_star = np.log10(np.maximum(flux_star, 1e-30))
-            f_interp = interp1d(log_wno_star, log_flux_star, kind='linear', 
-                                bounds_error=False, fill_value=np.log10(1e-30))
+            # Log-space interpolation
+            interpolator = interp1d(np.log10(wno_star), np.log10(flux_star), kind='linear',
+                                    fill_value='extrapolate', bounds_error=False)
+            fine_flux_star = 10**interpolator(np.log10(wno_planet))
 
-            # Get interpolated values
-            log_flux_interp = f_interp(np.log10(wno_planet))
-            flux_interp = 10**log_flux_interp
+            # Compute binned flux using trapezoidal integration
+            fine_flux_star[:] = [np.trapz(fine_flux_star[(wno_planet >= wno_planet[i]) & 
+                                                        (wno_planet <= wno_planet[i+1])], 
+                                        x=-1/wno_planet[(wno_planet >= wno_planet[i]) & 
+                                                        (wno_planet <= wno_planet[i+1])]) 
+                                if i < len(wno_planet) - 1 else 0 for i in range(len(wno_planet))]
 
-            # Combine both methods
-            mask = fine_flux_star < flux_interp
-            fine_flux_star[mask] = flux_interp[mask]
+            # Linear extrapolation for the last point
+            if len(wno_planet) > 2:
+                slope = (fine_flux_star[-2] - fine_flux_star[-3]) / (wno_planet[-2] - wno_planet[-3])
+                fine_flux_star[-1] = fine_flux_star[-2] + slope * (wno_planet[-1] - wno_planet[-2])
 
-            # Handle remaining zeros
-            mask = (fine_flux_star == 0) | np.isnan(fine_flux_star)
+            # Handle NaNs and zeros
+            mask = np.logical_or(np.isnan(fine_flux_star), fine_flux_star == 0)
             if np.sum(mask) > 20:
-                print(f"[DEBUG] Replacing {np.sum(mask)} zero bins using np.interp.")
+                print(f"Having to replace {len(fine_wno_star[mask])} zeros or nans in stellar spectra")
                 non_zero_indices = np.where(~mask)[0]
-                fine_flux_star[mask] = np.interp(fine_wno_star[mask], fine_wno_star[non_zero_indices], fine_flux_star[non_zero_indices])
-
-            # Normalize to preserve total energy
-            original_sum = np.sum(-0.5 * np.diff(1.0 / wno_star) * (flux_star[:-1] + flux_star[1:]))
-            new_sum = np.sum(fine_flux_star)
-
-            if new_sum > 0:
-                fine_flux_star *= original_sum / new_sum
-
-            # Final diagnostics
-            print(f"[DEBUG] Final integrated flux: {np.sum(fine_flux_star):.4e} erg/cm^2/s")
-            print(f"[DEBUG] Reference blackbody flux: {5.67e-5 * 6000**4:.4e} erg/cm^2/s")
-            print(f"[DEBUG] Flux difference: {original_sum - new_sum:.4e} erg/cm^2/s")
-            print(list(fine_flux_star))
-            """
-
-
-
-
+                fine_flux_star[mask] = np.interp(wno_planet[mask], wno_planet[non_zero_indices], fine_flux_star[non_zero_indices])
 
 
             opannection.unshifted_stellar_spec = fine_flux_star  

--- a/picaso/justdoit.py
+++ b/picaso/justdoit.py
@@ -319,9 +319,9 @@ def picaso(bundle,opacityclass, dimension = '1d',calculation='reflected',
                                                         atm.level['pressure'],ubar1,
                                                         atm.surf_reflect, atm.hard_surface,
                                                         #setting wno to zero since only used for climate, calctype only gets TOA flx 
-                                                        wno*0, calc_type=0)
-
-
+                                                        wno*0,
+                                                        calc_type=calc_type)
+                    
 
                 elif rt_method == 'SH':
                     flux, flux_layers = get_thermal_SH(nlevel, wno, nwno, ng, nt, atm.level['temperature'],
@@ -480,7 +480,6 @@ def picaso(bundle,opacityclass, dimension = '1d',calculation='reflected',
     if  ('reflected' in calculation):
         albedo = compress_disco(nwno, cos_theta, xint_at_top, gweight, tweight,F0PI)
         returns['albedo'] = albedo 
-
 
         # This is attempt to get the compress_disco to return the integrated fluxes
         # However, its mixing an albedo calc and an itegration calc I think
@@ -6177,4 +6176,3 @@ def correct_profile(temp,pressure,wh,min_temp):
 
     return temp
 '''
-

--- a/picaso/justdoit.py
+++ b/picaso/justdoit.py
@@ -277,7 +277,7 @@ def picaso(bundle,opacityclass, dimension = '1d',calculation='reflected',
                                                     frac_a,frac_b,frac_c,constant_back,constant_forward,
                                                     get_toa_intensity=1,get_lvl_flux=int(atm.get_lvl_flux),
                                                     toon_coefficients=toon_coefficients,b_top=b_top) 
-
+                                        
                 xint_at_top += xint*gauss_wts[ig]
 
                 if get_lvl_flux: 
@@ -315,6 +315,7 @@ def picaso(bundle,opacityclass, dimension = '1d',calculation='reflected',
                     #                                    DTAU_OG[:,:,ig], W0_no_raman[:,:,ig], COSB_OG[:,:,ig], 
                     #                                    atm.level['pressure'],ubar1,
                     #                                    atm.surf_reflect, atm.hard_surface, tridiagonal)
+
                     flux,lvl_fluxes  = get_thermal_1d(nlevel, wno,nwno,ng,nt,atm.level['temperature'],
                                                         DTAU_OG[:,:,ig], W0_no_raman[:,:,ig], COSB_OG[:,:,ig], 
                                                         atm.level['pressure'],ubar1,
@@ -1702,12 +1703,11 @@ class inputs():
             #fix issue if there are zeros in certain bins 
             mask = np.logical_or(np.isnan(fine_flux_star), fine_flux_star == 0)
             if len(fine_wno_star[mask])>20:
-                print(f"Having to replace {len(fine_wno_star[mask])} zeros or nans in stellar spectra with interpolated values. It is advised you check this is correct and something has not gone wrong by plotting classname.inputs['star']['wno'] vs classname.inputs'star'['flux']")
+                print(f"Having to replace {len(fine_wno_star[mask])} zeros or nans in stellar spectra with interpolated values.It is advised you check this is correct and something has not gone wrong by plotting classname.inputs['star']['wno'] vs classname.inputs'star'['flux']")
                 non_zero_indices = np.where(~mask)
                 zero_nans = np.interp(fine_wno_star[mask], fine_wno_star[non_zero_indices], fine_flux_star[non_zero_indices])
                 fine_flux_star[mask] = zero_nans  
             """
-
             # Ensure valid values for interpolation
             mask_valid = flux_star > 1e-30  
             if not np.all(mask_valid):
@@ -1736,8 +1736,8 @@ class inputs():
                 print(f"Having to replace {len(fine_wno_star[mask])} zeros or nans in stellar spectra")
                 non_zero_indices = np.where(~mask)[0]
                 fine_flux_star[mask] = np.interp(wno_planet[mask], wno_planet[non_zero_indices], fine_flux_star[non_zero_indices])
-
-
+            
+ 
             opannection.unshifted_stellar_spec = fine_flux_star  
             bin_flux_star = fine_flux_star          
         else :
@@ -4519,6 +4519,8 @@ def load_planet(df, opacity, phase_angle = 0, stellar_db='ck04models', verbose=F
         #define gravity
         start_case.gravity(mass=Mp, mass_unit=u.Unit('M_jup'),
                             radius=Rp, radius_unit=u.Unit('R_jup')) #any astropy units available
+        
+
 
         #define star
         start_case.star(opacity, temp,logmh,logg,radius=Rstar, radius_unit=u.Unit('R_sun'),

--- a/picaso/justdoit.py
+++ b/picaso/justdoit.py
@@ -225,7 +225,7 @@ def picaso(bundle,opacityclass, dimension = '1d',calculation='reflected',
 
     if dimension == '1d':
         #lastly grab needed opacities for the problem
-        get_opacities(atm,exclude_mol=exclude_mol)
+        get_opacities(atm)
         #only need to get opacities for one pt profile
 
         #There are two sets of dtau,tau,w0,g in the event that the user chooses to use delta-eddington

--- a/picaso/justdoit.py
+++ b/picaso/justdoit.py
@@ -225,7 +225,7 @@ def picaso(bundle,opacityclass, dimension = '1d',calculation='reflected',
 
     if dimension == '1d':
         #lastly grab needed opacities for the problem
-        get_opacities(atm)
+        get_opacities(atm,exclude_mol=exclude_mol)
         #only need to get opacities for one pt profile
 
         #There are two sets of dtau,tau,w0,g in the event that the user chooses to use delta-eddington
@@ -1087,6 +1087,8 @@ def get_contribution(bundle, opacityclass, at_tau=1, dimension='1d'):
     #gets both continuum and needed rayleigh cross sections 
     #relies on continuum molecules are added into the opacity 
     #database. Rayleigh molecules are all in `rayleigh.py` 
+    print(opacityclass.rayleigh_molecules)
+
     atm.get_needed_continuum(opacityclass.rayleigh_molecules,
                              opacityclass.avail_continuum)
 

--- a/picaso/optics.py
+++ b/picaso/optics.py
@@ -1329,8 +1329,8 @@ class RetrieveCKs():
         player = atmosphere.layer['pressure']/atmosphere.c.pconv
     
         cia_molecules = atmosphere.continuum_molecules
+        #cia_molecules = [['H2', 'H2'], ['H2', 'CH4'], ['H2', 'He']]
 
-    
         self.continuum_opa = {key[0]+key[1]:np.zeros((nlayer,self.nwno)) for key in cia_molecules}
         #continuum
         #find nearest temp for cia grid
@@ -1415,7 +1415,7 @@ class RetrieveCKs():
 
         conn.close()
 
-    def get_opacities(self, atmosphere):
+    def get_opacities(self, atmosphere, exclude_mol=1):
         """
         Gets opacities from the premixed tables only 
 
@@ -1428,7 +1428,7 @@ class RetrieveCKs():
         self.get_continuum(atmosphere)
         self.get_pre_mix_ck(atmosphere)
     
-    def get_opacities_deq_onfly(self, atmosphere):
+    def get_opacities_deq_onfly(self, atmosphere, exclude_mol=1):
         """
         Gets opacities from the individual gas CK tables and mixes them 
         accordingly 
@@ -2120,6 +2120,7 @@ class RetrieveOpacities():
         tlayer =atmosphere.layer['temperature']
         player = atmosphere.layer['pressure']/atmosphere.c.pconv
         molecules = atmosphere.molecules
+
         cia_molecules = atmosphere.continuum_molecules        
         #struture opacity dictionary
         self.molecular_opa = {key:np.zeros((nlayer, self.nwno)) for key in molecules}
@@ -2176,7 +2177,7 @@ class RetrieveOpacities():
   
         conn.close() 
 
-    def get_opacities_nearest(self,atmosphere,  exclude_mol=1):
+    def get_opacities_nearest(self, atmosphere, exclude_mol=1):
         """
         Get's opacities using the atmosphere class
         """

--- a/picaso/optics.py
+++ b/picaso/optics.py
@@ -698,13 +698,15 @@ class RetrieveCKs():
             self.get_available_rayleigh()
 
 
-        # Determine which function is used to get the function of getting opacities
         if isinstance(self.gases_fly, list) and len(self.gases_fly) > 0:
-            # If the user passes a list of gases, set get_opacities to the on-the-fly method
+            # If a list of gases is provided, use the on‐the‐fly method.
             self.get_opacities = self.get_opacities_deq_onfly
         else:
-            # Otherwise, default to the pre-mixed method
-            self.get_opacities = self.get_opacities
+            # Otherwise, use the premixed method.
+            self.get_opacities = self.__class__.get_opacities.__get__(self)
+
+
+
         return
 
     def get_h5_data(self):
@@ -1413,10 +1415,7 @@ class RetrieveCKs():
 
         conn.close()
 
-
-
-
-    def get_opacities(self, atmosphere,exclude_mol=1):
+    def get_opacities(self, atmosphere):
         """
         Gets opacities from the premixed tables only 
 
@@ -1429,7 +1428,7 @@ class RetrieveCKs():
         self.get_continuum(atmosphere)
         self.get_pre_mix_ck(atmosphere)
     
-    def get_opacities_deq_onfly(self, atmosphere, exclude_mol=1):
+    def get_opacities_deq_onfly(self, atmosphere):
         """
         Gets opacities from the individual gas CK tables and mixes them 
         accordingly 
@@ -1440,7 +1439,6 @@ class RetrieveCKs():
             Not yet functional for CK option since they are premixed. For individual 
             CK molecules, this will ignore the optical contribution from one molecule. 
         """
- 
         self.get_continuum(atmosphere)
         self.mix_my_opacities_gasesfly(atmosphere)
 

--- a/picaso/optics.py
+++ b/picaso/optics.py
@@ -705,10 +705,6 @@ class RetrieveCKs():
         else:
             # Otherwise, default to the pre-mixed method
             self.get_opacities = self.get_opacities
-
-
-
-
         return
 
     def get_h5_data(self):

--- a/picaso/optics.py
+++ b/picaso/optics.py
@@ -1319,139 +1319,100 @@ class RetrieveCKs():
 
 
     def get_continuum(self, atmosphere):
-        """
-        Retrieve continuum opacity data for the given atmosphere and interpolate
-        both in temperature and (if needed) in wavelength.
-
-        This function:
-        - Opens a local database connection.
-        - Determines the appropriate continuum temperatures for each atmospheric layer.
-        - Constructs SQL queries to retrieve opacity data for the nearest low and high temperatures.
-        - Interpolates the opacity between the two temperatures using inverse-temperature weighting.
-        - Interpolates the resulting opacity onto the correct wavelength grid only if necessary.
-
-        Parameters
-        ----------
-        atmosphere : object
-            An atmosphere instance that contains:
-                - c.nlayer: number of layers.
-                - layer: a dictionary with keys 'temperature' and 'pressure'.
-                - continuum_molecules: list of continuum molecules (each given as a tuple; e.g. ('CIA', 'H2-H2')).
-                - c.pconv: pressure conversion factor.
-        """
-        # Open a local connection.
+        #open connection 
         cur, conn = self.open_local()
-
-        nlayer = atmosphere.c.nlayer
-        tlayer = atmosphere.layer['temperature']
+    
+        nlayer =atmosphere.c.nlayer
+        tlayer =atmosphere.layer['temperature']
+        player = atmosphere.layer['pressure']/atmosphere.c.pconv
+    
         cia_molecules = atmosphere.continuum_molecules
 
-        # Initialize the continuum opacity dictionary.
-        # Each key is a molecule identifier (e.g. concatenation of molecule tuple elements)
-        # and the value is an array with shape (nlayer, self.nwno).
-        self.continuum_opa = {mol[0] + mol[1]: np.zeros((nlayer, self.nwno)) for mol in cia_molecules}
-
-        # --- Determine the nearest temperatures for each layer ---
+    
+        self.continuum_opa = {key[0]+key[1]:np.zeros((nlayer,self.nwno)) for key in cia_molecules}
+        #continuum
+        #find nearest temp for cia grid
+    
+        #tcia = [np.unique(self.cia_temps)[find_nearest(np.unique(self.cia_temps),i)] for i in tlayer]
         sorted_cia_temps = np.sort(self.cia_temps)
         tcia_low = np.zeros_like(tlayer)
         tcia_high = np.zeros_like(tlayer)
-
-        for i, t in enumerate(tlayer):
-            diff = sorted_cia_temps - t
+        for t,i in zip(tlayer,range(len(tlayer))) :
+            diff = sorted_cia_temps -t
             if t <= sorted_cia_temps[0]:
                 tcia_low[i] = sorted_cia_temps[0]
                 tcia_high[i] = sorted_cia_temps[1]
             elif t >= sorted_cia_temps[-1]:
                 tcia_low[i] = sorted_cia_temps[-2]
                 tcia_high[i] = sorted_cia_temps[-1]
-            else:
-                # For temperatures in between, choose the nearest lower and higher temperatures.
-                templow = max(diff[diff <= 0])
-                temphigh = min(diff[diff > 0])
-                tcia_low[i] = t + templow
-                tcia_high[i] = t + temphigh
-
-        # --- Build SQL queries ---
-        if len(tcia_low) == 1:
-            query_temp_low = "AND temperature = '{}'".format(str(tcia_low[0]))
+            else :
+                templow = max(diff[np.where(diff <= 0)])
+                temphigh = min(diff[np.where(diff > 0)])
+                tcia_low[i], tcia_high[i] = t+templow,t+temphigh
+    
+    
+        #if user only runs a single molecule or temperature
+        if len(tcia_low) ==1: 
+            query_temp_low = """AND temperature= '{}' """.format(str(tcia_low[0]))
         else:
-            query_temp_low = "AND temperature in " + str(tuple(tcia_low))
-        if len(tcia_high) == 1:
-            query_temp_high = "AND temperature = '{}'".format(str(tcia_high[0]))
+            query_temp_low = 'AND temperature in '+str(tuple(tcia_low) )
+        if len(tcia_high) ==1: 
+            query_temp_high= """AND temperature= '{}' """.format(str(tcia_high[0]))
         else:
-            query_temp_high = "AND temperature in " + str(tuple(tcia_high))
+            query_temp_high = 'AND temperature in '+str(tuple(tcia_high) )
 
-        # Molecule query.
-        cia_mol_keys = list(self.continuum_opa.keys())
-        if len(cia_mol_keys) == 1:
-            query_mol = "WHERE molecule = '{}'".format(cia_mol_keys[0])
+        cia_mol = list(self.continuum_opa.keys())
+        if len(cia_mol) ==1: 
+            query_mol = """WHERE molecule= '{}' """.format(str(cia_mol[0]))
         else:
-            query_mol = "WHERE molecule in " + str(tuple(cia_mol_keys))
+            query_mol = 'WHERE molecule in '+str(tuple(cia_mol) )       
 
-        # --- Retrieve low-temperature opacity data ---
-        cur.execute(
-            "SELECT molecule, temperature, opacity FROM continuum {} {}"
-            .format(query_mol, query_temp_low)
-        )
+        cur.execute("""SELECT molecule,temperature,opacity 
+                    FROM continuum 
+                    {} 
+                    {}""".format(query_mol, query_temp_low))
+    
         data_low = cur.fetchall()
-        if not data_low:
-            raise ValueError("No low temperature opacity data found for the specified molecules")
-        # Create a lookup dictionary with keys like "molecule_temperature".
-        data_low = {f"{mol}_{temp}": opa for mol, temp, opa in data_low}
+        data_low = dict((x+'_'+str(y), dat) for x, y,dat in data_low)
+    
+        cur.execute("""SELECT molecule,temperature,opacity 
+                    FROM continuum 
+                    {} 
+                    {}""".format(query_mol, query_temp_high))
 
-        # --- Retrieve high-temperature opacity data ---
-        cur.execute(
-            "SELECT molecule, temperature, opacity FROM continuum {} {}"
-            .format(query_mol, query_temp_high)
-        )
         data_high = cur.fetchall()
-        if not data_high:
-            raise ValueError("No high temperature opacity data found for the specified molecules")
-        data_high = {f"{mol}_{temp}": opa for mol, temp, opa in data_high}
+        data_high = dict((x+'_'+str(y), dat) for x, y,dat in data_high)
+        outs = {i:[] for i in self.continuum_opa.keys()}
+        for i in self.continuum_opa.keys():
+            #y2_array = self.cia_splines[i]
+            
+            for jlow, jhigh,ind in zip(tcia_low, tcia_high,range(nlayer)):
+                h = tcia_high[ind] - tcia_low[ind]
+                a = (tcia_high[ind] - tlayer[ind])/h
+                b = (tlayer[ind]- tcia_low[ind])/h
+                
+                t_inv = 1/tlayer[ind]
+                t_inv_low = 1/tcia_low[ind]
+                t_inv_hi = 1/tcia_high[ind]
+                
+                t_interp = ((t_inv - t_inv_low) / (t_inv_hi - t_inv_low))
+    
+                #whlow= np.where(jlow == self.cia_temps)
+                #whhigh = np.where(jhigh == self.cia_temps)
+    
+                #interpolated = data_high[i+'_'+str(jhigh)] #a*data_low[i+'_'+str(jlow)]+b*data_high[i+'_'+str(jhigh)]#+((a**3-a)*y2_array[whlow[0][0],:]+(b**3-b)*y2_array[whhigh[0][0]])*(h**2)/6.0
 
-        # --- Process each molecule and layer ---
-        for molecule in self.continuum_opa.keys():
-            for ind in range(nlayer):
-                # Get temperatures for this layer.
-                t_low = tcia_low[ind]
-                t_high = tcia_high[ind]
-                t_actual = tlayer[ind]
-                h = t_high - t_low
-                if h == 0:
-                    raise ValueError(f"Zero temperature difference for layer {ind}: t_low and t_high are identical.")
+                #outs[i] += [[data_low[i+'_'+str(jlow)], data_high[i+'_'+str(jhigh)]]]
+    
+                
 
-                # Compute the interpolation factor using inverse temperature.
-                t_inv = 1 / t_actual
-                t_inv_low = 1 / t_low
-                t_inv_high = 1 / t_high
-                t_interp = (t_inv - t_inv_low) / (t_inv_high - t_inv_low)
-
-                # Construct the lookup keys.
-                low_key = f"{molecule}_{t_low}"
-                high_key = f"{molecule}_{t_high}"
-                if low_key not in data_low or high_key not in data_high:
-                    raise KeyError(f"Missing opacity data for molecule {molecule} at temperatures {t_low} or {t_high}")
-
-                # Temperature interpolation in logarithmic space.
-                try:
-                    ln_kappa = np.exp((1 - t_interp) * np.log(data_low[low_key]) +
-                                    t_interp * np.log(data_high[high_key]))
-                except ValueError as e:
-                    raise ValueError(f"Error in temperature interpolation for molecule {molecule}: {str(e)}")
-
-                # --- Wavelength grid interpolation (only if necessary) ---
-                if len(ln_kappa) != self.nwno:
-                    original_wno = np.linspace(min(self.wno), max(self.wno), len(ln_kappa))
-
-                    # Verify that the original wavelength grid is monotonically increasing.
-                    if not np.all(np.diff(original_wno) > 0):
-                        raise ValueError("Original wavelength grid must be monotonically increasing")
-                    ln_kappa = np.interp(self.wno, original_wno, ln_kappa)
-
-                # Assign the (possibly interpolated) opacity data.
-                self.continuum_opa[molecule][ind, :] = ln_kappa
+                ln_kappa = np.exp(((1-t_interp) * np.log(data_low[i+'_'+str(jlow)]) ) +
+                                ((t_interp)   * np.log(data_high[i+'_'+str(jhigh)])))
+                
+                self.continuum_opa[i][ind,:] = ln_kappa
 
         conn.close()
+
 
 
 

--- a/picaso/optics.py
+++ b/picaso/optics.py
@@ -654,9 +654,9 @@ class RetrieveCKs():
     on_fly : bool, deprecated
         deprecated, used to turn on and off the old method of doing diseq with 
     """
-    def __init__(self, ck_dir, cont_dir, wave_range=None, 
-        deq=False, gases_fly=None, on_fly=False):
+    def __init__(self, ck_dir, cont_dir, wave_range=None, deq=False, gases_fly=None, on_fly=False):
         self.ck_filename = ck_dir
+        self.gases_fly = gases_fly
 
         #check to see if new hdf5 files are being used 
         if 'hdf5' in self.ck_filename: 
@@ -665,8 +665,7 @@ class RetrieveCKs():
         else: 
             #read in the full abundance file sot hat we can check the number of kcoefficient layers 
             #this should either be 1460 or 1060
-            self.full_abunds =  pd.read_csv(os.path.join(self.ck_filename,'full_abunds'),
-                sep='\s+')
+            self.full_abunds =  pd.read_csv(os.path.join(self.ck_filename,'full_abunds'), sep='\s+')
             self.kcoeff_layers = self.full_abunds.shape[0]
 
         if deq == False :
@@ -686,36 +685,32 @@ class RetrieveCKs():
             self.get_available_rayleigh()
             #self.run_cia_spline() #not actually being used
         
-        elif deq == True : # ) and (on_fly== True) :
-            #self.get_gauss_pts_661_1460() repetetive code function
-            
+        elif deq == True:            
             if 'hdf5' not in self.ck_filename: 
                 self.get_legacy_data_1460(wave_range)
             
             self.get_new_wvno_grid_661()
             
             opa_filepath  = os.path.join(__refdata__, 'climate_INPUTS/661')
-            self.load_kcoeff_arrays_first(opa_filepath,gases_fly)
+            self.load_kcoeff_arrays_first(opa_filepath)
             self.db_filename = cont_dir
             self.get_available_continuum()
             self.get_available_rayleigh()
-            #self.run_cia_spline_661() #not actually being used
 
-        
-        #elif (deq == True) and (on_fly == False) :
-            #this option follows the old method where we used 
-            #661 fortran files computed by T.Karidali
-            #this is why we have to use the 1060 files instead 
-            #of the 1460 files
-        #    self.get_legacy_data_1060(wave_range,deq=deq)
-        #    self.get_new_wvno_grid_661()
-            
-        #    opa_filepath  = os.path.join(__refdata__, 'climate_INPUTS/661')
-        #    self.load_kcoeff_arrays(opa_filepath)
-        #    self.db_filename = cont_dir
-        #    self.get_available_continuum()
-        #    self.get_available_rayleigh()
-        #    self.run_cia_spline_661()
+
+        # Determine which function is used to get the function of getting opacities
+        if isinstance(self.gases_fly, list) and len(self.gases_fly) > 0:
+            # If the user passes a list of gases, set get_opacities to the on-the-fly method
+            print("Testing, should be doing deq on fly")
+            self.get_opacities = self.get_opacities_deq_onfly
+        else:
+            # Otherwise, default to the pre-mixed method
+            print("Testing, not doing on the fly mixing")
+            self.get_opacities = self.get_opacities
+
+
+
+
         return
 
     def get_h5_data(self):
@@ -730,8 +725,10 @@ class RetrieveCKs():
             self.temps = f["temperatures"][:]   
             self.gauss_pts = f["gauss_pts"][:]  
             self.gauss_wts = f["gauss_wts"][:] 
+
             #want the axes to be [npressure, ntemperature, nwave, ngauss ]
             self.kappa =f["kcoeffs"][:] 
+
             self.full_abunds =  pd.DataFrame(data=f["abunds"][:] ,
                                              columns=[x.decode('utf-8') for x in f["abunds_map"][:]])
             
@@ -1142,14 +1139,21 @@ class RetrieveCKs():
         self.molecular_opa = ln_kappa*6.02214086e+23  #avogadro constant!        
       
     
-    def mix_my_opacities_gasesfly(self,bundle,atmosphere,gases_fly):
+    def mix_my_opacities_gasesfly(self, atmosphere):
         """
         Top Function to perform "on-the-fly" mixing and then interpolating of 5 opacity sources from Amundsen et al. (2017)
         """
         nlayer=atmosphere.c.nlayer
+
+
+        #mixes = []
+        #for imol in self.gases_fly: 
+        #    mixes += [bundle.inputs['atmosphere']['profile'][imol].values]
+
         mixes = []
-        for imol in gases_fly: 
-            mixes += [bundle.inputs['atmosphere']['profile'][imol].values]
+        for imol in self.gases_fly: 
+            mixes += [atmosphere.layer['mixingratios'][imol].values]
+ 
                 
         
         indices, t_interp,p_interp = self.get_mixing_indices(atmosphere) # gets nearest neighbor indices
@@ -1275,7 +1279,7 @@ class RetrieveCKs():
         self.molecular_opa = np.exp(self.kappa[ind_p, ind_t, :, :])*6.02214086e+23  #avogadro constant!        
 
 
-    def load_kcoeff_arrays_first(self,path,gases_fly):
+    def load_kcoeff_arrays_first(self,path):
         """
         This loads and returns the kappa tables from
         opacity_factory.compute_ck_molecular()
@@ -1291,7 +1295,7 @@ class RetrieveCKs():
         check_hdf5=glob.glob(os.path.join(path,'*.hdf5'))
         check_npy=glob.glob(os.path.join(path,'*.npy'))
         self.kappas = []
-        for imol in gases_fly: 
+        for imol in self.gases_fly: 
             if os.path.join(path,f'{imol}_1460.hdf5') in check_hdf5:
                 with h5py.File(os.path.join(path,f'{imol}_1460.hdf5'), "r") as f:
                     #in a future code version we could get these things from the hdf5 file and not assume the 661 table
@@ -1330,7 +1334,6 @@ class RetrieveCKs():
     
         cia_molecules = atmosphere.continuum_molecules
 
-    
         self.continuum_opa = {key[0]+key[1]:np.zeros((nlayer,self.nwno)) for key in cia_molecules}
         #continuum
         #find nearest temp for cia grid
@@ -1405,11 +1408,9 @@ class RetrieveCKs():
                 #interpolated = data_high[i+'_'+str(jhigh)] #a*data_low[i+'_'+str(jlow)]+b*data_high[i+'_'+str(jhigh)]#+((a**3-a)*y2_array[whlow[0][0],:]+(b**3-b)*y2_array[whhigh[0][0]])*(h**2)/6.0
 
                 #outs[i] += [[data_low[i+'_'+str(jlow)], data_high[i+'_'+str(jhigh)]]]
-    
-                
 
                 ln_kappa = np.exp(((1-t_interp) * np.log(data_low[i+'_'+str(jlow)]) ) +
-                                ((t_interp)   * np.log(data_high[i+'_'+str(jhigh)])))
+                                  ((t_interp)   * np.log(data_high[i+'_'+str(jhigh)])))
                 
                 self.continuum_opa[i][ind,:] = ln_kappa
 
@@ -1429,7 +1430,7 @@ class RetrieveCKs():
         self.get_continuum(atmosphere)
         self.get_pre_mix_ck(atmosphere)
     
-    def get_opacities_deq_onfly(self, bundle, atmosphere,gases_fly=None):
+    def get_opacities_deq_onfly(self, atmosphere, exclude_mol=1):
         """
         Gets opacities from the individual gas CK tables and mixes them 
         accordingly 
@@ -1442,7 +1443,7 @@ class RetrieveCKs():
         """
  
         self.get_continuum(atmosphere)
-        self.mix_my_opacities_gasesfly(bundle , atmosphere,gases_fly)
+        self.mix_my_opacities_gasesfly(atmosphere)
 
     def adapt_array(arr):
         """needed to interpret bytes to array"""
@@ -1553,17 +1554,21 @@ class RetrieveCKs():
         self.full_abunds['pressure']= self.pressures[self.pressures>0]
         self.full_abunds['temperature'] = np.concatenate([[i]*max(self.nc_p) for i in self.temps])[self.pressures>0]
 
+
     ###### BEGIN deprecated functions ######
     # These are all from the old Karilid method of diseq
     # The disequilibrium on the fly code replaces these 
-    def load_kcoeff_arrays_deprecate(self,path):
+    def load_kcoeff_arrays_deprecate(self, path):
         """
         This loads and returns the kappa tables from Theodora's bin_mol files
         will have this very hardcoded.
         use this func only once before run begins
         """
         max_wind = 670 # this can change as well but hopefully not
+
+
         n_windows = 661 # wait for 196 , then this is 196
+
         npres = 18 # max pres grid #
         ntemp = 60 # max temp grid #
 
@@ -1640,19 +1645,22 @@ class RetrieveCKs():
         self.kappa_nh3 = knh3[:,:,0:self.nwno,0:self.ngauss]
         self.kappa_ch4 = kch4[:,:,0:self.nwno,0:self.ngauss]
 
-    def mix_my_opacities_deprecate(self,bundle,atmosphere):
+    def mix_my_opacities_deprecate(self, atmosphere):
         """
         Top Function to perform "on-the-fly" mixing and then interpolating of 5 opacity sources from Amundsen et al. (2017)
         """
-        mix_co =   bundle.inputs['atmosphere']['profile']['CO'] # mixing ratio of CO
-        mix_h2o =  bundle.inputs['atmosphere']['profile']['H2O'] # mixing ratio of H2O
-        mix_ch4 =  bundle.inputs['atmosphere']['profile']['CH4'] # mixing ratio of CH4
-        mix_nh3 =  bundle.inputs['atmosphere']['profile']['NH3'] # mixing ratio of NH3
-        '''
-        mix_co2 =  bundle.inputs['atmosphere']['profile']['CO2'] # will mix now
-        mix_n2 =   bundle.inputs['atmosphere']['profile']['N2']
-        mix_hcn =   bundle.inputs['atmosphere']['profile']['HCN']
-        '''
+        #mix_co =   bundle.inputs['atmosphere']['profile']['CO'] # mixing ratio of CO
+        #mix_h2o =  bundle.inputs['atmosphere']['profile']['H2O'] # mixing ratio of H2O
+        #mix_ch4 =  bundle.inputs['atmosphere']['profile']['CH4'] # mixing ratio of CH4
+        #mix_nh3 =  bundle.inputs['atmosphere']['profile']['NH3'] # mixing ratio of NH3
+
+
+        # Access mixing ratios directly from the 'atmosphere.layer' structure
+        mix_co = atmosphere.layer['mixingratios']['CO'].values  # mixing ratio of CO
+        mix_h2o = atmosphere.layer['mixingratios']['H2O'].values  # mixing ratio of H2O
+        mix_ch4 = atmosphere.layer['mixingratios']['CH4'].values  # mixing ratio of CH4
+        mix_nh3 = atmosphere.layer['mixingratios']['NH3'].values  # mixing ratio of NH3
+
         mix_rest= np.zeros_like(mix_co) #mixing ratio of the rest of the atmosphere
         
         
@@ -1751,9 +1759,9 @@ class RetrieveCKs():
         self.full_abunds['pressure']= self.pressures[self.pressures>0]
         self.full_abunds['temperature'] = np.concatenate([[i]*max(self.nc_p) for i in self.temps])[self.pressures>0]
 
-    def get_opacities_deq_deprecate(self, bundle, atmosphere):
+    def get_opacities_deq_deprecate(self, atmosphere):
         self.get_continuum(atmosphere)
-        self.mix_my_opacities(bundle , atmosphere)
+        self.mix_my_opacities(atmosphere)
    
     def run_cia_spline_deprecate(self):
  
@@ -1849,7 +1857,7 @@ class RetrieveOpacities():
     get_opacities 
         Gets opacities after user specifies atmospheric profile (e.g. full PT and Composition)
     """
-    def __init__(self, db_filename, raman_data, wave_range=None,location = 'local',resample=1):
+    def __init__(self, db_filename, raman_data, wave_range=None, location = 'local', resample=1):
 
         #monochromatic opacity option forces number of gauss points to 1
         self.ngauss = 1
@@ -1864,7 +1872,10 @@ class RetrieveOpacities():
         
         #raman cross sections 
         self.raman_db = pd.read_csv(raman_data,
-                     sep='\s+', skiprows=16,header=None, names=['ji','jf','vf','c','deltanu'])
+                                    sep='\s+',
+                                    skiprows=16, 
+                                    header=None,
+                                    names=['ji','jf','vf','c','deltanu'])
         
         #compute available Rayleigh scatterers 
         self.get_available_rayleigh()
@@ -2100,7 +2111,7 @@ class RetrieveOpacities():
         data =  dict((x+'_'+str(y), dat[::self.resample][self.loc]) for x,y,dat in data)       
         return data 
 
-    def get_opacities(self,atmosphere, exclude_mol=1):
+    def get_opacities(self, atmosphere, exclude_mol=1):
         """
         Get's opacities using the atmosphere class using interpolation for molecular, but not 
         continuum. Continuum opacity is grabbed via nearest neighbor methodology. 
@@ -2209,7 +2220,7 @@ class RetrieveOpacities():
             else: 
                 fac = exclude_mol[i]
             for j,ind in zip(ind_pt,range(nlayer)): # multiply by avogadro constant 
-                self.molecular_opa[i][ind, :] = fac*data[i+'_'+str(j)]*6.02214086e+23 #add to opacity bundle
+                self.molecular_opa[i][ind, :] = fac*data[i+'_'+str(j)]*6.02214086e+23 #add to opacity
 
         #continuum
         #find nearest temp for cia grid


### PR DESCRIPTION
-Created a code pathway to return integrated energy level fluxes when not running a climate calculation Issue #230 

-Added resort rebin capability to simple forward model calculation (outside of climate calculation). Issue #231 

-Improved the stellar flux rebinning, necessary for calculations where wavelength integrated stellar fluxes. Very little difference for Phoenix stellar models, possibly larger difference for coarser wavelength stellar models.

-Slight code cleanup in how climate assigns get_opacities function