### PR TITLE
HDF5 support for resampled opacity DB

### DIFF
--- a/docs/notebooks/G_opacities/5_HDF5Opacity_WIP.py
+++ b/docs/notebooks/G_opacities/5_HDF5Opacity_WIP.py
@@ -1,12 +1,12 @@
 # ---
 # jupyter:
 #   jupytext:
-#     custom_cell_magics: kql
+#     formats: ipynb,py:percent
 #     text_representation:
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.11.2
+#       jupytext_version: 1.19.1
 #   kernelspec:
 #     display_name: pic312
 #     language: python
@@ -14,31 +14,44 @@
 # ---
 
 # %% [markdown]
-# # Querying Opacities
+# # HDF5 Opacity Database Suport
 #
-# ``PICASO`` currently includes several different flavors of opacity database on Zenodo (incl different Rs, molecules, wavelength ranges). 
-#
-# We chose those use `sqlite3` for our database because of it's 1) user-friendliness, 2) speed, 3) scalability, 4) compatibility with parallel programming. In 2019, we tried out various other methods as well-- `json`, `hdf5`, `ascii`, `sqlalchemy`-- but `sqlite3` was truly better for this specific problem. Having revisited this problem recently `hdf5` has now outpaced `sqlite3` in terms of storage and performance. Therefore in future PICASO v5 we will move away from `sqlite3` and toward `hdf5` which has a much larger user base now. 
-#
-# In this tutorial you wil learn how to quickly grab any opacity data
+# ``PICASO`` is moving away from SQLite and toward HDF5. Currently, this notebook tutorial shows users how to: 
+# - transfer their existing SQLite database to HDF5 (the support for doing this includes options to decrease the float precision of the data to drastically reduce memory by ~factor of 2). 
+# - perform queries on the new HDF5 formatted data 
 
 # %%
 from picaso import justplotit as jpi
 from picaso import justdoit as jdi
-import warnings
-warnings.filterwarnings('ignore')
 import numpy as np
 import picaso.opacity_factory as opa
 #plotting
 jpi.output_notebook()
 
 # %% [markdown]
-# ## General Sqlite3 and how our database is structured
+# ## Transfer SQLite data to HDF5 format
 #
-# - 3 Tables: `header`, `continuum`, and `molecular`
-# - header: contains units and the wavenumber grid
-# - continuum: contains a grid continuum opacity and is temperature dependent
-# - molecular: contains all molecular opacity and is pressure-temperature dependent.
+# Some new parameters to consider for the function below: 
+#
+# - `compression` and `shuffle`: When lzf + shuffle compression is used, this decreases resampled opacity file sizes by a factor of 10.
+# - `storage_format`: HDF5 files can store opacities in two different formats: log10_uint16 and log10_float32. The log10_uint16 approach saves log10 opacities using unsigned 16 bit integers which will degrade accuracy by  < 0.04% in core tests (reflected + transmission + thermal). We do not guarantee that as the ceiling. We encourage users to test for their case of interest. 
+
+# %%
+#lets convert your default opacity file (note this will not delete or overwrite your default)
+opanxn = jdi.opannection()
+db_filename = opanxn.db_filename
+new_hdf5_filename = jdi.os.path.join(jdi.os.getcwd(),'test.hdf5')#'/data/picaso_dbs'
+opa.convert_sqlite_to_hdf5(
+    input_db=db_filename,#lets convert our current default to HDF5
+    output_hdf5=new_hdf5_filename,
+    compression='lzf',
+    shuffle=True,
+    storage_format="log10_uint16",
+    chunks=(1, 4096),
+    molecular_log10_floor=1e-50,
+    continuum_log10_floor=1e-100,
+    verbose=True,
+)
 
 # %% [markdown]
 # ## How to Query the Database
@@ -60,7 +73,7 @@ opa.get_metadata_item(db_filename, 'version'),opa.get_metadata_item(db_filename,
 # ### What Species, Pressures and Temperatures are Available
 
 # %%
-molecules, pt_pairs = opa.molecular_avail(db_filename)
+molecules, pt_pairs = opa.molecular_avail(new)
 
 # %%
 print(molecules)

--- a/picaso/justdoit.py
+++ b/picaso/justdoit.py
@@ -5,7 +5,7 @@ from .climate import  namedtuple,run_chemeq_climate_workflow,run_diseq_climate_w
 
 
 from .wavelength import get_cld_input_grid
-from .optics import RetrieveOpacities,compute_opacity,RetrieveCKs
+from .optics import RetrieveOpacities, RetrieveOpacitiesHDF5, compute_opacity, RetrieveCKs
 from .disco import get_angles_1d, get_angles_3d, compute_disco, compress_disco, compress_thermal
 from .justplotit import numba_cumsum, mean_regrid
 from .build_3d_input import regrid_xarray
@@ -1334,13 +1334,17 @@ def find_press(at_tau, a, b, c):
         at_press.append(np.interp([at_tau],a[:,iw],c)[0])
     return at_press
 
-def opannection(wave_range = None, filename_db = None, 
-                resample=1, method='resampled',
-                ck_db=None, raman_db = None, 
-                preload_gases='all',
-                #deq= False, on_fly=False,
-                #gases_fly =None,ck=False,
-                verbose=False):
+def opannection(
+    wave_range=None, 
+    filename_db=None, 
+    resample=1, 
+    method='resampled',
+    ck_db=None, 
+    raman_db=None, 
+    preload_gases='all',
+    query_method='linear',
+    verbose=False,
+):
     """
     Sets up database connection to opacities. 
 
@@ -1364,6 +1368,13 @@ def opannection(wave_range = None, filename_db = None,
     method : str 
         By default method='resampled'
         Other options include: ['preweighted','resortrebin']
+    query_method : str
+        Only used when ``method='resampled'``. Controls how molecular opacities
+        are fetched from the resampled database.
+        Options are:
+        - ``'nearest'``: nearest-neighbor selection in PT space
+        - ``'linear'``: bilinear interpolation in PT space
+        Default is ``'linear'``.
     ck_db : str 
         Can be: 
         - (required if method is preweighted) ASCII dir of ck file
@@ -1402,10 +1413,22 @@ def opannection(wave_range = None, filename_db = None,
         if resample != 1:
             if verbose:print("YOU ARE REQUESTING RESAMPLING!! This could degrade the precision of your spectral calculations so should be used with caution. If you are unsure check out this tutorial: https://natashabatalha.github.io/picaso/notebooks/10_ResamplingOpacities.html")
 
-        opacityclass=RetrieveOpacities(
-                    filename_db, 
-                    raman_db,
-                    wave_range = wave_range, resample = resample)  
+        if filename_db.lower().endswith(('.h5', '.hdf5')):
+            opacityclass = RetrieveOpacitiesHDF5(
+                db_filename=filename_db,
+                raman_data=raman_db,
+                wave_range=wave_range, 
+                resample=resample,
+                query_method=query_method
+            )
+        else:
+            opacityclass = RetrieveOpacities(
+                db_filename=filename_db,
+                raman_data=raman_db,
+                wave_range=wave_range, 
+                resample=resample,
+                query_method=query_method
+            )  
         if verbose: print("verbose=True; Molecule set=",opacityclass.molecules) 
     elif ((method == 'resampled') & isinstance(ck_db,str)):
         raise Exception("ck_db was supplied but method is set to resampled. Change kwarg method='preweighted' to use the preweighted ck tables")

--- a/picaso/justdoit.py
+++ b/picaso/justdoit.py
@@ -1342,7 +1342,7 @@ def opannection(
     ck_db=None, 
     raman_db=None, 
     preload_gases='all',
-    query_method='linear',
+    query_method='nearest',
     verbose=False,
 ):
     """
@@ -1374,7 +1374,6 @@ def opannection(
         Options are:
         - ``'nearest'``: nearest-neighbor selection in PT space
         - ``'linear'``: bilinear interpolation in PT space
-        Default is ``'linear'``.
     ck_db : str 
         Can be: 
         - (required if method is preweighted) ASCII dir of ck file

--- a/picaso/opacity_factory.py
+++ b/picaso/opacity_factory.py
@@ -18,6 +18,40 @@ from .io_utils import read_visscher_2121
 
 __refdata__ = os.environ.get('picaso_refdata')
 
+def _decode_hdf5_string(value):
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    if isinstance(value, np.ndarray):
+        if value.shape == ():
+            return _decode_hdf5_string(value.item())
+        return [_decode_hdf5_string(i) for i in value.tolist()]
+    return str(value)
+
+def _decode_hdf5_opacity_block(raw_block, storage_format, y_min=None, y_max=None, return_log=False):
+    storage_format = _decode_hdf5_string(storage_format)
+    if storage_format == 'log10_float32':
+        decoded = np.asarray(raw_block, dtype=np.float64)
+        return decoded if return_log else 10**decoded
+    if storage_format == 'log10_uint16':
+        if y_min is None or y_max is None:
+            raise Exception("log10_uint16 datasets require scalar y_min and y_max attributes")
+        y_min = np.asarray(y_min)
+        y_max = np.asarray(y_max)
+        if y_min.shape != () or y_max.shape != ():
+            raise Exception("log10_uint16 datasets require scalar y_min and y_max attributes")
+        y_min = float(y_min)
+        y_max = float(y_max)
+        raw_block = np.asarray(raw_block, dtype=np.float64)
+        if y_max == y_min:
+            decoded = np.zeros(raw_block.shape, dtype=np.float64) + y_min
+        else:
+            decoded = y_min + (y_max - y_min) * (raw_block / float(np.iinfo(np.uint16).max))
+        return decoded if return_log else 10**decoded
+    raise Exception(
+        f"Do not recognize HDF5 opacity storage format: {storage_format}. "
+        "Supported formats are log10_uint16 and log10_float32."
+    )
+
 def restruct_continuum(original_file,colnames, new_wno,new_db, overwrite):
     """
     The continuum factory takes the CIA opacity file and adds in extra sources of 
@@ -870,6 +904,15 @@ def convert_sqlite_to_hdf5(
     cur.execute("SELECT DISTINCT temperature FROM continuum ORDER BY temperature")
     continuum_temperatures = np.asarray([row[0] for row in cur.fetchall()], dtype=np.float64)
 
+    # Check for metadata table
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='metadata'")
+    has_metadata = cur.fetchone() is not None
+    if has_metadata:
+        cur.execute("SELECT key, value FROM metadata")
+        metadata = cur.fetchall()
+    else:
+        metadata = []
+
     with h5py.File(output_hdf5, "w") as f:
         header = f.create_group("header")
         header.create_dataset("wavenumber_grid", data=wavenumber_grid)
@@ -892,6 +935,11 @@ def convert_sqlite_to_hdf5(
         header.attrs["molecular_unit"] = str(molecular_unit)
         header.attrs["molecular_log10_floor"] = float(molecular_log10_floor)
         header.attrs["continuum_log10_floor"] = float(continuum_log10_floor)
+
+        if has_metadata:
+            meta_group = f.create_group("metadata")
+            for key, value in metadata:
+                meta_group.create_dataset(key, data=np.array(value, dtype=string_dtype))
 
         molecular_group = f.create_group("molecular")
         total_molecules = len(molecule_names)
@@ -1530,11 +1578,11 @@ def molecular_avail(db_file):
         cur, conn = open_local(db_file)
         cur.execute('SELECT ptid, pressure, temperature FROM molecular')
         data= cur.fetchall()
-    pt_pairs = sorted(list(set(data)),key=lambda x: (x[0]) )
+        pt_pairs = sorted(list(set(data)),key=lambda x: (x[0]) )
 
-    cur.execute('SELECT molecule FROM molecular')
-    molecules = [ str(i) for i in np.unique(cur.fetchall())]
-    return list(molecules), pt_pairs
+        cur.execute('SELECT molecule FROM molecular')
+        molecules = [ str(i) for i in np.unique(cur.fetchall())]
+        return list(molecules), pt_pairs
 def find_nearest_1d(array,value):
     #small program to find the nearest neighbor in a matrix
     ar , iar ,ic = np.unique(array,return_index=True,return_counts=True)
@@ -1546,80 +1594,106 @@ def find_nearest_1d(array,value):
     return idx
 def get_continuum(db_file, species, temperature):
     """
-    Grab continuum opacity from sqlite database 
+    Grab continuum opacity from sqlite or HDF5 database 
 
     Parameters
     ----------
     db_file : str 
-        sqlite3 database filename 
+        sqlite3 or HDF5 database filename 
     species : list of str 
         Single species name. you can run continuum_avail to see what species are present.
     temperature : list of float
         Temperature to grab. can grab available temperatures from continuum_avail
     """
-    cur, conn = open_local(db_file)
+    if h5py.is_hdf5(db_file):
+        with h5py.File(db_file, "r") as f:
+            if not isinstance(temperature, list):
+                raise Exception('Make Temperature a list, even if it is single valued')
+            if not isinstance(species, list):
+                raise Exception('Make Species Input a list, even if it is single valued')
 
-    if not isinstance(temperature,list):
-        raise Exception('Make Temperature a list, even if it is single valued')
-    if not isinstance(species,list):
-        raise Exception('Make Species Input a list, even if it is single valued')
-    cur.execute('SELECT temperature FROM continuum')
-    cia_temperatures = np.unique(cur.fetchall())
+            cia_temperatures = f["header/continuum_temperatures"][:]
+            temp_nearest = [cia_temperatures[find_nearest_1d(cia_temperatures, t)] for t in temperature]
 
-    temp_nearest = [cia_temperatures[find_nearest_1d(cia_temperatures,t)] for t in temperature]
+            restruct = {i: {} for i in species}
+            for ispec in species:
+                if ispec in f["continuum"]:
+                    dataset = f[f"continuum/{ispec}"]
+                    storage_format = dataset.attrs.get("storage_format")
+                    y_min = dataset.attrs.get("y_min")
+                    y_max = dataset.attrs.get("y_max")
+                    
+                    for t in set(temp_nearest):
+                        idx = np.where(cia_temperatures == t)[0][0]
+                        opacity = _decode_hdf5_opacity_block(dataset[idx:idx+1, :], storage_format, y_min, y_max)[0]
+                        restruct[ispec][t] = opacity
 
-    #cur.execute("""SELECT molecule,temperature,opacity
-    #            FROM continuum
-    #            WHERE molecule in {}
-    #            AND temperature in {}""".format(str(tuple(species)), str(tuple(temp_nearest))))
+            restruct['wavenumber'] = f["header/wavenumber_grid"][:]
+        return restruct
+    else:
+        cur, conn = open_local(db_file)
 
-    if (len(species) == 1) and (len(temp_nearest) > 1):
-        placeholders = ', '.join(['?'] * len(temp_nearest))
-        cur.execute(f"""SELECT molecule,temperature,opacity
-                FROM continuum
-                WHERE molecule = ?
-                AND temperature in ({placeholders})""", [species[0]] + list(temp_nearest))
-    elif (len(species) > 1) and (len(temp_nearest) == 1):
-        placeholders = ', '.join(['?'] * len(species))
-        cur.execute(f"""SELECT molecule,temperature,opacity
-                FROM continuum
-                WHERE molecule in ({placeholders})
-                AND temperature = ?""", list(species) + [temp_nearest[0]])
-    elif (len(species) == 1) and (len(temp_nearest) == 1):
-        cur.execute("""SELECT molecule,temperature,opacity
+        if not isinstance(temperature,list):
+            raise Exception('Make Temperature a list, even if it is single valued')
+        if not isinstance(species,list):
+            raise Exception('Make Species Input a list, even if it is single valued')
+        cur.execute('SELECT temperature FROM continuum')
+        cia_temperatures = np.unique(cur.fetchall())
+
+        temp_nearest = [cia_temperatures[find_nearest_1d(cia_temperatures,t)] for t in temperature]
+
+        #cur.execute("""SELECT molecule,temperature,opacity
+        #            FROM continuum
+        #            WHERE molecule in {}
+        #            AND temperature in {}""".format(str(tuple(species)), str(tuple(temp_nearest))))
+
+        if (len(species) == 1) and (len(temp_nearest) > 1):
+            placeholders = ', '.join(['?'] * len(temp_nearest))
+            cur.execute(f"""SELECT molecule,temperature,opacity
                     FROM continuum
                     WHERE molecule = ?
-                    AND temperature = ?""", (species[0], temp_nearest[0]))
-    else:
-        placeholders_spec = ', '.join(['?'] * len(species))
-        placeholders_temp = ', '.join(['?'] * len(temp_nearest))
-        cur.execute(f"""SELECT molecule,temperature,opacity
+                    AND temperature in ({placeholders})""", [species[0]] + list(temp_nearest))
+        elif (len(species) > 1) and (len(temp_nearest) == 1):
+            placeholders = ', '.join(['?'] * len(species))
+            cur.execute(f"""SELECT molecule,temperature,opacity
                     FROM continuum
-                    WHERE molecule in ({placeholders_spec})
-                    AND temperature in ({placeholders_temp})""", list(species) + list(temp_nearest))
+                    WHERE molecule in ({placeholders})
+                    AND temperature = ?""", list(species) + [temp_nearest[0]])
+        elif (len(species) == 1) and (len(temp_nearest) == 1):
+            cur.execute("""SELECT molecule,temperature,opacity
+                        FROM continuum
+                        WHERE molecule = ?
+                        AND temperature = ?""", (species[0], temp_nearest[0]))
+        else:
+            placeholders_spec = ', '.join(['?'] * len(species))
+            placeholders_temp = ', '.join(['?'] * len(temp_nearest))
+            cur.execute(f"""SELECT molecule,temperature,opacity
+                        FROM continuum
+                        WHERE molecule in ({placeholders_spec})
+                        AND temperature in ({placeholders_temp})""", list(species) + list(temp_nearest))
 
-    
-    data= cur.fetchall()
-    restruct = {i:{} for i in species}
+        
+        data= cur.fetchall()
+        restruct = {i:{} for i in species}
 
-    for im, it, dat in data : restruct[im][it] = dat
+        for im, it, dat in data : restruct[im][it] = dat
 
-    cur.execute('SELECT wavenumber_grid FROM header')
-    wave_grid = cur.fetchone()[0]
+        cur.execute('SELECT wavenumber_grid FROM header')
+        wave_grid = cur.fetchone()[0]
 
-    conn.close()
-    restruct['wavenumber'] = wave_grid
+        conn.close()
+        restruct['wavenumber'] = wave_grid
 
-    return restruct
+        return restruct
 
 def get_molecular(db_file, species, temperature,pressure):
     """
-    Grab molecular opacity from sqlite database 
+    Grab molecular opacity from sqlite or HDF5 database 
 
     Parameters
     ----------
     db_file : str 
-        sqlite3 database filename 
+        sqlite3 or HDF5 database filename 
     species : list of str 
         Single species name. you can run molecular_avail to see what species are present.
     temperature : list of flaot,int
@@ -1635,66 +1709,113 @@ def get_molecular(db_file, species, temperature,pressure):
         one temperature at two pressures, then this should be input as 
         t = [100,100] (and pressure would be p=[0.1,1] for instance)
     """
-    if not isinstance(temperature,list):
-        raise Exception('Make temperature a list, even if it is single valued')
-    if not isinstance(pressure,list):
-        raise Exception('Make pressure a list, even if it is single valued')
-    if not isinstance(species,list):
-        raise Exception('Make Species a list, even if it is single valued')
-    if len(temperature) != len(pressure):
-        raise Exception('Temperature and Pressure must be the same size because these \
-            are treated as pairs. t=[500,600], p=[1.0, 0.01] will grab [500,1.0 ] and [600,0.01]')
-    
-    cur, conn = open_local(db_file)
-    #get pt pairs
-    cur.execute('SELECT ptid, pressure, temperature FROM molecular')
-    data= cur.fetchall()    
-    pt_pairs = sorted(list(set(data)),key=lambda x: (x[0]) )
-    #here's a little code to get out the correct pair (so we dont have to worry about getting the exact number right)
-    ind_pt = [min(pt_pairs, key=lambda c: math.hypot(c[1]- coordinate[0], c[2]-coordinate[1]))[0]
-              for coordinate in  zip(pressure,temperature)]
-    if (len(species) == 1) and (len(ind_pt) > 1):
-        placeholders = ', '.join(['?'] * len(ind_pt))
-        cur.execute(f"""SELECT molecule,ptid,pressure,temperature,opacity
-                FROM molecular
-                WHERE molecule = ?
-                AND ptid in ({placeholders})""", [species[0]] + list(ind_pt))
-    elif (len(species) > 1) and (len(ind_pt) == 1):
-        placeholders = ', '.join(['?'] * len(species))
-        cur.execute(f"""SELECT molecule,ptid,pressure,temperature,opacity
-                FROM molecular
-                WHERE molecule in ({placeholders})
-                AND ptid = ?""", list(species) + [ind_pt[0]])
-    elif (len(species) == 1) and (len(ind_pt) == 1):
-        cur.execute("""SELECT molecule,ptid,pressure,temperature,opacity
+    if h5py.is_hdf5(db_file):
+        with h5py.File(db_file, "r") as f:
+            if not isinstance(temperature, list):
+                raise Exception('Make temperature a list, even if it is single valued')
+            if not isinstance(pressure, list):
+                raise Exception('Make pressure a list, even if it is single valued')
+            if not isinstance(species, list):
+                raise Exception('Make Species a list, even if it is single valued')
+            if len(temperature) != len(pressure):
+                raise Exception('Temperature and Pressure must be the same size because these \
+                    are treated as pairs. t=[500,600], p=[1.0, 0.01] will grab [500,1.0 ] and [600,0.01]')
+
+            pt_pairs_array = f["header/pt_pairs"][:]
+            # pt_pairs in sqlite was list of tuples (ptid, pressure, temperature)
+            pt_pairs = [(int(row[0]), float(row[1]), float(row[2])) for row in pt_pairs_array]
+
+            # here's a little code to get out the correct pair
+            ind_pt = [min(pt_pairs, key=lambda c: math.hypot(c[1] - coordinate[0], c[2] - coordinate[1]))[0]
+                    for coordinate in zip(pressure, temperature)]
+
+            temp_nearest = [pt_pairs[i - 1][2] for i in ind_pt]
+            pres_nearest = [pt_pairs[i - 1][1] for i in ind_pt]
+            
+            restruct = {i: {} for i in species}
+            for ispec in species:
+                if ispec in f["molecular"]:
+                    dataset = f[f"molecular/{ispec}"]
+                    storage_format = dataset.attrs.get("storage_format")
+                    y_min = dataset.attrs.get("y_min")
+                    y_max = dataset.attrs.get("y_max")
+                    
+                    for i_pair in range(len(ind_pt)):
+                        ptid = ind_pt[i_pair]
+                        t = temp_nearest[i_pair]
+                        p = pres_nearest[i_pair]
+                        
+                        if t not in restruct[ispec]:
+                            restruct[ispec][t] = {}
+                        
+                        # ptid in HDF5 is 1-indexed based on row order
+                        idx = ptid - 1
+                        opacity = _decode_hdf5_opacity_block(dataset[idx:idx+1, :], storage_format, y_min, y_max)[0]
+                        restruct[ispec][t][p] = opacity
+
+            restruct['wavenumber'] = f["header/wavenumber_grid"][:]
+        return restruct
+    else:
+        if not isinstance(temperature,list):
+            raise Exception('Make temperature a list, even if it is single valued')
+        if not isinstance(pressure,list):
+            raise Exception('Make pressure a list, even if it is single valued')
+        if not isinstance(species,list):
+            raise Exception('Make Species a list, even if it is single valued')
+        if len(temperature) != len(pressure):
+            raise Exception('Temperature and Pressure must be the same size because these \
+                are treated as pairs. t=[500,600], p=[1.0, 0.01] will grab [500,1.0 ] and [600,0.01]')
+        
+        cur, conn = open_local(db_file)
+        #get pt pairs
+        cur.execute('SELECT ptid, pressure, temperature FROM molecular')
+        data= cur.fetchall()    
+        pt_pairs = sorted(list(set(data)),key=lambda x: (x[0]) )
+        #here's a little code to get out the correct pair (so we dont have to worry about getting the exact number right)
+        ind_pt = [min(pt_pairs, key=lambda c: math.hypot(c[1]- coordinate[0], c[2]-coordinate[1]))[0]
+                for coordinate in  zip(pressure,temperature)]
+        if (len(species) == 1) and (len(ind_pt) > 1):
+            placeholders = ', '.join(['?'] * len(ind_pt))
+            cur.execute(f"""SELECT molecule,ptid,pressure,temperature,opacity
                     FROM molecular
                     WHERE molecule = ?
-                    AND ptid = ?""", (species[0], ind_pt[0]))
-    else:
-        placeholders_spec = ', '.join(['?'] * len(species))
-        placeholders_ptid = ', '.join(['?'] * len(ind_pt))
-        cur.execute(f"""SELECT molecule,ptid,pressure,temperature,opacity
+                    AND ptid in ({placeholders})""", [species[0]] + list(ind_pt))
+        elif (len(species) > 1) and (len(ind_pt) == 1):
+            placeholders = ', '.join(['?'] * len(species))
+            cur.execute(f"""SELECT molecule,ptid,pressure,temperature,opacity
                     FROM molecular
-                    WHERE molecule in ({placeholders_spec})
-                    AND ptid in ({placeholders_ptid})""", list(species) + list(ind_pt))
+                    WHERE molecule in ({placeholders})
+                    AND ptid = ?""", list(species) + [ind_pt[0]])
+        elif (len(species) == 1) and (len(ind_pt) == 1):
+            cur.execute("""SELECT molecule,ptid,pressure,temperature,opacity
+                        FROM molecular
+                        WHERE molecule = ?
+                        AND ptid = ?""", (species[0], ind_pt[0]))
+        else:
+            placeholders_spec = ', '.join(['?'] * len(species))
+            placeholders_ptid = ', '.join(['?'] * len(ind_pt))
+            cur.execute(f"""SELECT molecule,ptid,pressure,temperature,opacity
+                        FROM molecular
+                        WHERE molecule in ({placeholders_spec})
+                        AND ptid in ({placeholders_ptid})""", list(species) + list(ind_pt))
 
 
-    data= cur.fetchall()
+        data= cur.fetchall()
 
-    temp_nearest = [pt_pairs[i-1][2] for i in ind_pt]
-    pres_nearest = [pt_pairs[i-1][1] for i in ind_pt]
-    restruct = {i:{} for i in species}
-    for i in restruct.keys():
-        for t in temp_nearest:
-            restruct[i][t] = {}
-    for im, iid,ip,it, dat in data : restruct[im][it][ip] = dat
+        temp_nearest = [pt_pairs[i-1][2] for i in ind_pt]
+        pres_nearest = [pt_pairs[i-1][1] for i in ind_pt]
+        restruct = {i:{} for i in species}
+        for i in restruct.keys():
+            for t in temp_nearest:
+                restruct[i][t] = {}
+        for im, iid,ip,it, dat in data : restruct[im][it][ip] = dat
 
-    cur.execute('SELECT wavenumber_grid FROM header')
-    wave_grid = cur.fetchone()[0]
+        cur.execute('SELECT wavenumber_grid FROM header')
+        wave_grid = cur.fetchone()[0]
 
-    conn.close()
-    restruct['wavenumber'] = wave_grid
-    return restruct
+        conn.close()
+        restruct['wavenumber'] = wave_grid
+        return restruct
 
 def delete_molecule(mol, db_filename):
     """
@@ -2374,12 +2495,12 @@ def get_all_metadata(db_path):
 
 def get_metadata_item(db_path, key):
   """
-  Retrieves a metadata item by key.
+  Retrieves a metadata item by key from SQLite or HDF5.
 
   Parameters
   ----------   
   db_path : str 
-    Path to the SQLite database file.
+    Path to the SQLite or HDF5 database file.
   key : str
     The metadata key.
 
@@ -2387,24 +2508,39 @@ def get_metadata_item(db_path, key):
   -------
       The metadata value associated with the key, or None if the key is not found.
   """
-  try:
-      conn = sqlite3.connect(db_path)
-      cursor = conn.cursor()
-
-      cursor.execute("SELECT value FROM metadata WHERE key=?", (key,))
-      result = cursor.fetchone()
-
-      if result:
-          return result[0]  # Return the value (first element of the tuple)
-      else:
+  if h5py.is_hdf5(db_path):
+      try:
+          with h5py.File(db_path, "r") as f:
+              if "metadata" in f and key in f["metadata"]:
+                  val = f[f"metadata/{key}"]
+                  if val.shape == ():
+                      return _decode_hdf5_string(val[()])
+                  else:
+                      return _decode_hdf5_string(val[:])
+              else:
+                  return None
+      except Exception as e:
+          print(f"An error occurred: {e}")
           return None
+  else:
+      try:
+          conn = sqlite3.connect(db_path)
+          cursor = conn.cursor()
 
-  except sqlite3.Error as e:
-      print(f"An error occurred: {e}")
-      return None  # Return None in case of error
-  finally:
-      if conn:
-          conn.close()
+          cursor.execute("SELECT value FROM metadata WHERE key=?", (key,))
+          result = cursor.fetchone()
+
+          if result:
+              return result[0]  # Return the value (first element of the tuple)
+          else:
+              return None
+
+      except sqlite3.Error as e:
+          print(f"An error occurred: {e}")
+          return None  # Return None in case of error
+      finally:
+          if conn:
+              conn.close()
 
 def add_metadata_table(db_path):
     """

--- a/picaso/opacity_factory.py
+++ b/picaso/opacity_factory.py
@@ -2454,11 +2454,11 @@ def add_all_metadata(filename, version_number, default, resolution, wavemin, wav
         add = 'default_'
     else: 
         add = ''
-    add_metadata_item(f, 'version',add+version_number)
-    add_metadata_item(f, 'resolution',resolution)
-    add_metadata_item(f, 'wavemin',wavemin)
-    add_metadata_item(f, 'wavemax',wavemax)
-    add_metadata_item(f, 'zenodo',zenodo_doi)
+    add_metadata_item(filename, 'version',add+version_number)
+    add_metadata_item(filename, 'resolution',resolution)
+    add_metadata_item(filename, 'wavemin',wavemin)
+    add_metadata_item(filename, 'wavemax',wavemax)
+    add_metadata_item(filename, 'zenodo',zenodo_doi)
 
 def get_ck_tables(path, preload_gases=None, avail_continuum=None):
     """

--- a/picaso/opacity_factory.py
+++ b/picaso/opacity_factory.py
@@ -1502,19 +1502,34 @@ def vresample_and_insert_molecular(molecule, min_wavelength, max_wavelength, new
 
 
 def continuum_avail(db_file):
-    cur, conn = open_local(db_file)
-    #what molecules inside db exist?
-    cur.execute('SELECT molecule FROM continuum')
-    molecules = [str(i) for i in np.unique(cur.fetchall())]
-    cur.execute('SELECT temperature FROM continuum')
-    cia_temperatures = list(np.unique(cur.fetchall()))
-    conn.close()
-    return molecules, cia_temperatures
+    if h5py.is_hdf5(db_file):
+        with h5py.File(db_file, "r") as f:
+            molecules = [x.decode("utf-8") if isinstance(x, bytes) else x for x in f["header/continuum_molecules"][:]]
+            cia_temperatures = list(f["header/continuum_temperatures"][:])
+        return molecules, cia_temperatures
+    else:
+        cur, conn = open_local(db_file)
+        #what molecules inside db exist?
+        cur.execute('SELECT molecule FROM continuum')
+        molecules = [str(i) for i in np.unique(cur.fetchall())]
+        cur.execute('SELECT temperature FROM continuum')
+        cia_temperatures = list(np.unique(cur.fetchall()))
+        conn.close()
+        return molecules, cia_temperatures
 
 def molecular_avail(db_file):
-    cur, conn = open_local(db_file)
-    cur.execute('SELECT ptid, pressure, temperature FROM molecular')
-    data= cur.fetchall()
+    if h5py.is_hdf5(db_file):
+        with h5py.File(db_file, "r") as f:
+            molecules = [x.decode("utf-8") if isinstance(x, bytes) else x for x in f["header/molecules"][:]]
+            pt_pairs_array = f["header/pt_pairs"][:]
+            # pt_pairs in sqlite was list of tuples (ptid, pressure, temperature)
+            # ptid is int, pressure and temperature are float
+            pt_pairs = [(int(row[0]), float(row[1]), float(row[2])) for row in pt_pairs_array]
+        return list(molecules), pt_pairs
+    else:
+        cur, conn = open_local(db_file)
+        cur.execute('SELECT ptid, pressure, temperature FROM molecular')
+        data= cur.fetchall()
     pt_pairs = sorted(list(set(data)),key=lambda x: (x[0]) )
 
     cur.execute('SELECT molecule FROM molecular')

--- a/picaso/opacity_factory.py
+++ b/picaso/opacity_factory.py
@@ -18,7 +18,6 @@ from .io_utils import read_visscher_2121
 
 __refdata__ = os.environ.get('picaso_refdata')
 
-
 def restruct_continuum(original_file,colnames, new_wno,new_db, overwrite):
     """
     The continuum factory takes the CIA opacity file and adds in extra sources of 
@@ -737,6 +736,249 @@ def create_grid(min_wavelength, max_wavelength, constant_R):
         newwl[j] = newwl[j-1]*spacing
     
     return 1e4/newwl[::-1]
+
+
+def _encode_log10_uint16(opacity, floor):
+    arr = np.asarray(opacity, dtype=np.float64)
+    if np.any(~np.isfinite(arr)):
+        raise ValueError("Opacity array contains NaN or inf values")
+    if np.any(arr < 0.0):
+        raise ValueError("Opacity array contains negative values")
+
+    log_arr = np.log10(np.maximum(arr, floor))
+    y_min = float(np.min(log_arr))
+    y_max = float(np.max(log_arr))
+
+    if y_max == y_min:
+        encoded = np.zeros(log_arr.shape, dtype=np.uint16)
+    else:
+        scaled = (log_arr - y_min) / (y_max - y_min)
+        encoded = np.rint(scaled * float(np.iinfo(np.uint16).max)).astype(np.uint16)
+
+    return encoded, y_min, y_max
+
+
+def _encode_log10_uint16_stacked(opacity_rows, floor):
+    stacked = np.vstack([np.asarray(row, dtype=np.float64) for row in opacity_rows])
+    return _encode_log10_uint16(stacked, floor=floor)
+
+
+def _encode_log10_float32_stacked(opacity_rows, floor):
+    stacked = np.vstack([np.asarray(row, dtype=np.float64) for row in opacity_rows])
+    if np.any(~np.isfinite(stacked)):
+        raise ValueError("Opacity array contains NaN or inf values")
+    if np.any(stacked < 0.0):
+        raise ValueError("Opacity array contains negative values")
+    return np.log10(np.maximum(stacked, floor)).astype(np.float32)
+
+
+def convert_sqlite_to_hdf5(
+    input_db,
+    output_hdf5,
+    compression='lzf',
+    shuffle=True,
+    storage_format="log10_uint16",
+    chunks=(1, 4096),
+    molecular_log10_floor=1e-50,
+    continuum_log10_floor=1e-100,
+    verbose=True,
+):
+    """
+    Convert a resampled PICASO SQLite opacity database to the HDF5 layout used by
+    the runtime HDF5 resampled-opacity backend.
+
+    The output file contains:
+
+    - ``/header`` metadata for the PT grid, continuum temperatures, and wavenumber grid
+    - ``/molecular/<molecule>`` datasets with shape ``(n_pt, n_wno)``
+    - ``/continuum/<species>`` datasets with shape ``(n_temp, n_wno)``
+
+    Supported storage formats are:
+
+    - ``log10_uint16``: quantized ``log10(opacity)`` plus per-dataset ``y_min``/``y_max``
+    - ``log10_float32``: raw ``log10(opacity)`` stored as ``float32``
+
+    Parameters
+    ----------
+    input_db : str
+        Path to the input SQLite resampled-opacity database.
+    output_hdf5 : str
+        Path to the output HDF5 file.
+    compression : {None, 'lzf'}, optional
+        Optional HDF5 dataset compression. ``None`` writes uncompressed datasets.
+    shuffle : bool, optional
+        If ``True``, enable the HDF5 shuffle filter on written datasets.
+    storage_format : {'log10_uint16', 'log10_float32'}, optional
+        On-disk opacity representation for both molecular and continuum datasets.
+    chunks : tuple of int, optional
+        HDF5 chunk shape used when writing compressed datasets. Defaults to
+        ``(1, 4096)``.
+    molecular_log10_floor : float, optional
+        Positive floor applied to molecular opacities before taking ``log10``.
+        Defaults to ``1e-50``.
+    continuum_log10_floor : float, optional
+        Positive floor applied to continuum opacities before taking ``log10``.
+        Defaults to ``1e-100``.
+    verbose : bool, optional
+        If ``True``, print progress while writing molecular and continuum datasets.
+        Defaults to ``True``.
+
+    Notes
+    -----
+    This function preserves the row ordering from the SQLite database. The HDF5
+    runtime backend uses row indices directly, so the important invariant is that
+    the stored dataset row order matches the ``pt_pairs`` metadata written into
+    the file.
+    """
+    if compression not in {None, "lzf"}:
+        raise ValueError(f"Unsupported compression: {compression}")
+    if chunks is not None:
+        if len(chunks) != 2:
+            raise ValueError("chunks must be a length-2 tuple like (1, 4096)")
+        chunks = tuple(int(i) for i in chunks)
+        if chunks[0] <= 0 or chunks[1] <= 0:
+            raise ValueError("chunk dimensions must be positive")
+    if molecular_log10_floor <= 0.0:
+        raise ValueError("molecular_log10_floor must be positive")
+    if continuum_log10_floor <= 0.0:
+        raise ValueError("continuum_log10_floor must be positive")
+    if storage_format not in {"log10_uint16", "log10_float32"}:
+        raise ValueError(f"Unsupported storage_format: {storage_format}")
+
+    string_dtype = h5py.string_dtype(encoding="utf-8")
+
+    cur, conn = open_local(input_db)
+
+    cur.execute(
+        "SELECT pressure_unit, temperature_unit, wavenumber_grid, continuum_unit, molecular_unit FROM header LIMIT 1"
+    )
+    pressure_unit, temperature_unit, wavenumber_grid, continuum_unit, molecular_unit = cur.fetchone()
+    wavenumber_grid = np.asarray(wavenumber_grid, dtype=np.float64)
+
+    cur.execute("SELECT ptid, pressure, temperature FROM molecular")
+    pt_pairs = sorted(list(set(cur.fetchall())), key=lambda x: x[0])
+    pt_pairs_array = np.asarray(pt_pairs, dtype=np.float64)
+    ptids = pt_pairs_array[:, 0].astype(int)
+    pressures = pt_pairs_array[:, 1].astype(np.float64)
+    temperatures = pt_pairs_array[:, 2].astype(np.float64)
+
+    cur.execute("SELECT DISTINCT molecule FROM molecular ORDER BY molecule")
+    molecule_names = [row[0] for row in cur.fetchall()]
+
+    cur.execute("SELECT DISTINCT molecule FROM continuum ORDER BY molecule")
+    continuum_names = [row[0] for row in cur.fetchall()]
+    cur.execute("SELECT DISTINCT temperature FROM continuum ORDER BY temperature")
+    continuum_temperatures = np.asarray([row[0] for row in cur.fetchall()], dtype=np.float64)
+
+    with h5py.File(output_hdf5, "w") as f:
+        header = f.create_group("header")
+        header.create_dataset("wavenumber_grid", data=wavenumber_grid)
+        header.create_dataset("pressure", data=pressures)
+        header.create_dataset("temperature", data=temperatures)
+        header.create_dataset("ptid", data=ptids)
+        header.create_dataset("pt_pairs", data=pt_pairs_array)
+        header.create_dataset("molecules", data=np.asarray(molecule_names, dtype=object), dtype=string_dtype)
+        header.create_dataset(
+            "continuum_molecules",
+            data=np.asarray(continuum_names, dtype=object),
+            dtype=string_dtype,
+        )
+        header.create_dataset("continuum_temperatures", data=continuum_temperatures)
+        header.create_dataset("storage_format", data=np.array(storage_format, dtype=string_dtype))
+        header.create_dataset("continuum_storage_format", data=np.array(storage_format, dtype=string_dtype))
+        header.attrs["pressure_unit"] = str(pressure_unit)
+        header.attrs["temperature_unit"] = str(temperature_unit)
+        header.attrs["continuum_unit"] = str(continuum_unit)
+        header.attrs["molecular_unit"] = str(molecular_unit)
+        header.attrs["molecular_log10_floor"] = float(molecular_log10_floor)
+        header.attrs["continuum_log10_floor"] = float(continuum_log10_floor)
+
+        molecular_group = f.create_group("molecular")
+        total_molecules = len(molecule_names)
+        for i_molecule, molecule in enumerate(molecule_names, start=1):
+            if verbose:
+                print(f"[molecular {i_molecule}/{total_molecules}] Writing {molecule}")
+            cur.execute(
+                "SELECT ptid, opacity FROM molecular WHERE molecule = ? ORDER BY ptid",
+                (molecule,),
+            )
+            rows = cur.fetchall()
+            if len(rows) != len(ptids):
+                raise RuntimeError(
+                    f"Molecule {molecule} has {len(rows)} PT rows, expected {len(ptids)}"
+                )
+
+            opacity_rows = [np.asarray(opacity, dtype=np.float64) for _, opacity in rows]
+            if storage_format == "log10_uint16":
+                encoded, y_min, y_max = _encode_log10_uint16_stacked(
+                    opacity_rows,
+                    floor=molecular_log10_floor,
+                )
+            else:
+                encoded = _encode_log10_float32_stacked(
+                    opacity_rows,
+                    floor=molecular_log10_floor,
+                )
+
+            dataset_kwargs = {}
+            if compression is not None:
+                dataset_kwargs["compression"] = compression
+                dataset_kwargs["chunks"] = chunks
+            if shuffle:
+                dataset_kwargs["shuffle"] = True
+
+            dataset = molecular_group.create_dataset(molecule, data=encoded, **dataset_kwargs)
+            dataset.attrs["storage_format"] = storage_format
+            if storage_format == "log10_uint16":
+                dataset.attrs["y_min"] = np.float64(y_min)
+                dataset.attrs["y_max"] = np.float64(y_max)
+            dataset.attrs["log10_floor"] = float(molecular_log10_floor)
+
+        continuum_group = f.create_group("continuum")
+        total_continuum = len(continuum_names)
+        for i_continuum, molecule in enumerate(continuum_names, start=1):
+            if verbose:
+                print(f"[continuum {i_continuum}/{total_continuum}] Writing {molecule}")
+            cur.execute(
+                "SELECT temperature, opacity FROM continuum WHERE molecule = ? ORDER BY temperature",
+                (molecule,),
+            )
+            rows = cur.fetchall()
+            row_map = {float(temp): np.asarray(opacity, dtype=np.float64) for temp, opacity in rows}
+            opacity_rows = []
+            for temperature in continuum_temperatures:
+                if float(temperature) not in row_map:
+                    raise RuntimeError(
+                        f"Continuum molecule {molecule} is missing temperature {temperature}"
+                    )
+                opacity_rows.append(row_map[float(temperature)])
+
+            if storage_format == "log10_uint16":
+                encoded, y_min, y_max = _encode_log10_uint16_stacked(
+                    opacity_rows,
+                    floor=continuum_log10_floor,
+                )
+            else:
+                encoded = _encode_log10_float32_stacked(
+                    opacity_rows,
+                    floor=continuum_log10_floor,
+                )
+
+            dataset_kwargs = {}
+            if compression is not None:
+                dataset_kwargs["compression"] = compression
+                dataset_kwargs["chunks"] = chunks
+            if shuffle:
+                dataset_kwargs["shuffle"] = True
+
+            dataset = continuum_group.create_dataset(molecule, data=encoded, **dataset_kwargs)
+            dataset.attrs["storage_format"] = storage_format
+            if storage_format == "log10_uint16":
+                dataset.attrs["y_min"] = np.float64(y_min)
+                dataset.attrs["y_max"] = np.float64(y_max)
+            dataset.attrs["log10_floor"] = float(continuum_log10_floor)
+
+    conn.close()
     
 def insert_molecular_1060(molecule, min_wavelength, max_wavelength, new_R, 
             og_directory, new_db,dir_kark_ch4=None, dir_optical_o3=None):

--- a/picaso/optics.py
+++ b/picaso/optics.py
@@ -2412,10 +2412,11 @@ def _decode_hdf5_string(value):
     return str(value)
 
 
-def _decode_hdf5_opacity_block(raw_block, storage_format, y_min=None, y_max=None):
+def _decode_hdf5_opacity_block(raw_block, storage_format, y_min=None, y_max=None, return_log=False):
     storage_format = _decode_hdf5_string(storage_format)
     if storage_format == 'log10_float32':
-        return 10**(np.asarray(raw_block, dtype=np.float64))
+        decoded = np.asarray(raw_block, dtype=np.float64)
+        return decoded if return_log else 10**decoded
     if storage_format == 'log10_uint16':
         if y_min is None or y_max is None:
             raise Exception("log10_uint16 datasets require scalar y_min and y_max attributes")
@@ -2425,37 +2426,12 @@ def _decode_hdf5_opacity_block(raw_block, storage_format, y_min=None, y_max=None
             raise Exception("log10_uint16 datasets require scalar y_min and y_max attributes")
         y_min = float(y_min)
         y_max = float(y_max)
+        raw_block = np.asarray(raw_block, dtype=np.float64)
         if y_max == y_min:
-            log_block = np.zeros(np.asarray(raw_block).shape, dtype=np.float64) + y_min
+            decoded = np.zeros(raw_block.shape, dtype=np.float64) + y_min
         else:
-            log_block = y_min + (y_max - y_min) * (
-                np.asarray(raw_block, dtype=np.float64) / float(np.iinfo(np.uint16).max)
-            )
-        return 10**log_block
-    raise Exception(
-        f"Do not recognize HDF5 opacity storage format: {storage_format}. "
-        "Supported formats are log10_uint16 and log10_float32."
-    )
-
-
-def _decode_hdf5_log_block(raw_block, storage_format, y_min=None, y_max=None):
-    storage_format = _decode_hdf5_string(storage_format)
-    if storage_format == 'log10_float32':
-        return np.asarray(raw_block, dtype=np.float64)
-    if storage_format == 'log10_uint16':
-        if y_min is None or y_max is None:
-            raise Exception("log10_uint16 datasets require scalar y_min and y_max attributes")
-        y_min = np.asarray(y_min)
-        y_max = np.asarray(y_max)
-        if y_min.shape != () or y_max.shape != ():
-            raise Exception("log10_uint16 datasets require scalar y_min and y_max attributes")
-        y_min = float(y_min)
-        y_max = float(y_max)
-        if y_max == y_min:
-            return np.zeros(np.asarray(raw_block).shape, dtype=np.float64) + y_min
-        return y_min + (y_max - y_min) * (
-            np.asarray(raw_block, dtype=np.float64) / float(np.iinfo(np.uint16).max)
-        )
+            decoded = y_min + (y_max - y_min) * (raw_block / float(np.iinfo(np.uint16).max))
+        return decoded if return_log else 10**decoded
     raise Exception(
         f"Do not recognize HDF5 opacity storage format: {storage_format}. "
         "Supported formats are log10_uint16 and log10_float32."
@@ -2648,33 +2624,18 @@ class RetrieveOpacitiesHDF5(RetrieveOpacities):
         self.close()
 
     def _get_storage_format(self, dataset, default_value):
-        raw = dataset.attrs.get("storage_format", default_value)
-        return _decode_hdf5_string(raw)
+        return dataset.attrs.get("storage_format", default_value)
 
-    def _decode_dataset_rows(self, dataset, row_indices, default_storage_format):
+    def _decode_dataset_rows(self, dataset, row_indices, default_storage_format, return_log=False):
         row_indices = np.asarray(row_indices, dtype=np.int64)
         raw_block = dataset[row_indices, self._dataset_wave_slice]
         storage_format = self._get_storage_format(dataset, default_storage_format)
-        if storage_format == 'log10_uint16':
-            decoded = _decode_hdf5_opacity_block(
-                raw_block,
-                storage_format,
-                y_min=dataset.attrs.get("y_min"),
-                y_max=dataset.attrs.get("y_max"),
-            )
-        else:
-            decoded = _decode_hdf5_opacity_block(raw_block, storage_format)
-        return np.asarray(decoded, dtype=np.float64)
-
-    def _decode_dataset_rows_log(self, dataset, row_indices, default_storage_format):
-        row_indices = np.asarray(row_indices, dtype=np.int64)
-        raw_block = dataset[row_indices, self._dataset_wave_slice]
-        storage_format = self._get_storage_format(dataset, default_storage_format)
-        decoded = _decode_hdf5_log_block(
+        decoded = _decode_hdf5_opacity_block(
             raw_block,
             storage_format,
             y_min=dataset.attrs.get("y_min"),
             y_max=dataset.attrs.get("y_max"),
+            return_log=return_log,
         )
         return np.asarray(decoded, dtype=np.float64)
 
@@ -2737,26 +2698,10 @@ class RetrieveOpacitiesHDF5(RetrieveOpacities):
         self.loaded_continuum = None
 
     def preload_opacities(self,molecules,p_range,t_range):
-        self.preload=True
-        ind_pt = np.array(self.pt_pairs)
-        ind_pt = ind_pt[np.where(((ind_pt[:,1] >p_range[0]) &
-                           (ind_pt[:,1] <p_range[1])))]
-        ind_pt = ind_pt[np.where(((ind_pt[:,2] >t_range[0]) &
-                           (ind_pt[:,2] <t_range[1])))][:,0]
-        row_indices = np.array(
-            [self._ptid_to_row[int(ptid)] for ptid in np.asarray(ind_pt, dtype=np.int64)],
-            dtype=np.int64,
+        raise NotImplementedError(
+            "HDF5 preload_opacities() is no longer supported. The backend now "
+            "loads dense row blocks directly on demand and does not use a preload cache."
         )
-        self.loaded_molecules = self._load_molecular_blocks(
-            row_indices,
-            molecules,
-            decode_log=(self.query_method == 'linear'),
-        )
-
-        continuum_rows = np.where(
-            ((self.cia_temps > t_range[0]) & (self.cia_temps < t_range[1]))
-        )[0]
-        self.loaded_continuum = self._load_continuum_blocks(continuum_rows, self.avail_continuum)
 
     def _prepare_output_buffers(self, molecules, cia_molecules, nlayer):
         continuum_keys = [key[0] + key[1] for key in cia_molecules]
@@ -2789,25 +2734,19 @@ class RetrieveOpacitiesHDF5(RetrieveOpacities):
         row_lookup[requested_rows] = np.arange(requested_rows.size, dtype=np.int64)
         return requested_rows, row_lookup
 
-    def _load_molecular_blocks(self, row_indices, molecules, decode_log=False):
+    def _load_molecular_blocks(self, row_indices, molecules, return_log=False):
         requested_rows, row_lookup = self._build_row_lookup(row_indices, self._pt_ids.size)
         dense_blocks = {}
         for molecule in molecules:
             if molecule not in self._molecular_group:
                 raise Exception(f"Molecule {molecule} not found in HDF5 opacity file")
             dataset = self._molecular_group[molecule]
-            if decode_log:
-                dense_blocks[molecule] = self._decode_dataset_rows_log(
-                    dataset,
-                    requested_rows,
-                    self._default_molecular_storage_format,
-                )
-            else:
-                dense_blocks[molecule] = self._decode_dataset_rows(
-                    dataset,
-                    requested_rows,
-                    self._default_molecular_storage_format,
-                )
+            dense_blocks[molecule] = self._decode_dataset_rows(
+                dataset,
+                requested_rows,
+                self._default_molecular_storage_format,
+                return_log=return_log,
+            )
         return dense_blocks, row_lookup
 
     def _load_continuum_blocks(self, row_indices, continuum_species):
@@ -2822,30 +2761,6 @@ class RetrieveOpacitiesHDF5(RetrieveOpacities):
                 self._default_continuum_storage_format,
             )
         return dense_blocks, row_lookup
-
-    def _dense_cache_covers(self, loaded, names, row_indices):
-        if loaded is None:
-            return False
-        dense_blocks, row_lookup = loaded
-        for name in names:
-            if name not in dense_blocks:
-                return False
-        row_indices = np.asarray(row_indices, dtype=np.int64)
-        if row_indices.size == 0:
-            return True
-        if row_lookup.shape[0] <= int(np.max(row_indices)):
-            return False
-        return np.all(row_lookup[row_indices] >= 0)
-
-    def _get_molecular_blocks(self, row_indices, molecules, decode_log=False):
-        if self.preload and self._dense_cache_covers(self.loaded_molecules, molecules, row_indices):
-            return self.loaded_molecules
-        return self._load_molecular_blocks(row_indices, molecules, decode_log=decode_log)
-
-    def _get_continuum_blocks(self, row_indices, continuum_species):
-        if self.preload and self._dense_cache_covers(self.loaded_continuum, continuum_species, row_indices):
-            return self.loaded_continuum
-        return self._load_continuum_blocks(row_indices, continuum_species)
 
     def _prepare_linear_pt_state(self, tlayer, player):
         return _find_needed_pts_hdf5(
@@ -2875,7 +2790,7 @@ class RetrieveOpacitiesHDF5(RetrieveOpacities):
         )
         atmosphere.layer['pt_opa_index'] = (1 + required_rows).tolist()
 
-        dense_blocks, row_lookup = self._get_molecular_blocks(required_rows, molecules, decode_log=True)
+        dense_blocks, row_lookup = self._load_molecular_blocks(required_rows, molecules, return_log=True)
 
         local_low_low = row_lookup[row_low_low]
         local_hi_low = row_lookup[row_hi_low]
@@ -2904,7 +2819,7 @@ class RetrieveOpacitiesHDF5(RetrieveOpacities):
             np.asarray(tlayer, dtype=np.float64),
             np.asarray(self.cia_temps, dtype=np.float64),
         )
-        dense_continuum, continuum_lookup = self._get_continuum_blocks(continuum_rows, continuum_species)
+        dense_continuum, continuum_lookup = self._load_continuum_blocks(continuum_rows, continuum_species)
         continuum_local_rows = continuum_lookup[continuum_rows]
         for molecule in continuum_species:
             _fill_hdf5_nearest_block(
@@ -2933,7 +2848,7 @@ class RetrieveOpacitiesHDF5(RetrieveOpacities):
         )
         atmosphere.layer['pt_opa_index'] = nearest_ptids.tolist()
 
-        dense_blocks, row_lookup = self._get_molecular_blocks(nearest_rows, molecules, decode_log=False)
+        dense_blocks, row_lookup = self._load_molecular_blocks(nearest_rows, molecules, return_log=False)
         local_rows = row_lookup[nearest_rows]
 
         for molecule in molecules:
@@ -2950,7 +2865,7 @@ class RetrieveOpacitiesHDF5(RetrieveOpacities):
             np.asarray(tlayer, dtype=np.float64),
             np.asarray(self.cia_temps, dtype=np.float64),
         )
-        dense_continuum, continuum_lookup = self._get_continuum_blocks(continuum_rows, continuum_species)
+        dense_continuum, continuum_lookup = self._load_continuum_blocks(continuum_rows, continuum_species)
         continuum_local_rows = continuum_lookup[continuum_rows]
 
         for molecule in continuum_species:

--- a/picaso/optics.py
+++ b/picaso/optics.py
@@ -2429,7 +2429,7 @@ def _decode_hdf5_opacity_block(raw_block, storage_format, y_min=None, y_max=None
             log_block = np.zeros(np.asarray(raw_block).shape, dtype=np.float64) + y_min
         else:
             log_block = y_min + (y_max - y_min) * (
-                np.asarray(raw_block, dtype=np.float64) / 65535.0
+                np.asarray(raw_block, dtype=np.float64) / float(np.iinfo(np.uint16).max)
             )
         return 10**log_block
     raise Exception(
@@ -2454,7 +2454,7 @@ def _decode_hdf5_log_block(raw_block, storage_format, y_min=None, y_max=None):
         if y_max == y_min:
             return np.zeros(np.asarray(raw_block).shape, dtype=np.float64) + y_min
         return y_min + (y_max - y_min) * (
-            np.asarray(raw_block, dtype=np.float64) / 65535.0
+            np.asarray(raw_block, dtype=np.float64) / float(np.iinfo(np.uint16).max)
         )
     raise Exception(
         f"Do not recognize HDF5 opacity storage format: {storage_format}. "

--- a/picaso/optics.py
+++ b/picaso/optics.py
@@ -2462,6 +2462,133 @@ def _decode_hdf5_log_block(raw_block, storage_format, y_min=None, y_max=None):
     )
 
 
+@jit(nopython=True, cache=True)
+def _interpolate_hdf5_log_opacity(output, log_block, idx1, idx2, idx3, idx4, t_interp, p_interp, scale):
+    """Interpolate log10 opacity rows into a preallocated linear-opacity output buffer."""
+    nlayer, nwno = output.shape
+    for i in range(nlayer):
+        w1 = (1.0 - t_interp[i]) * (1.0 - p_interp[i])
+        w2 = t_interp[i] * (1.0 - p_interp[i])
+        w3 = t_interp[i] * p_interp[i]
+        w4 = (1.0 - t_interp[i]) * p_interp[i]
+        row1 = idx1[i]
+        row2 = idx2[i]
+        row3 = idx3[i]
+        row4 = idx4[i]
+        for j in range(nwno):
+            log_val = (
+                w1 * log_block[row1, j]
+                + w2 * log_block[row2, j]
+                + w3 * log_block[row3, j]
+                + w4 * log_block[row4, j]
+            )
+            output[i, j] = scale * (10.0 ** log_val)
+
+
+@jit(nopython=True, cache=True)
+def _find_needed_pts_hdf5(tlayer, player, t_inv_grid, p_log_grid, nc_p, temp_row_offsets):
+    nlayer = tlayer.size
+    t_interp = np.empty(nlayer, dtype=np.float64)
+    p_interp = np.empty(nlayer, dtype=np.float64)
+    row_low_low = np.empty(nlayer, dtype=np.int64)
+    row_hi_low = np.empty(nlayer, dtype=np.int64)
+    row_low_hi = np.empty(nlayer, dtype=np.int64)
+    row_hi_hi = np.empty(nlayer, dtype=np.int64)
+
+    for i in range(nlayer):
+        t_inv = 1.0 / tlayer[i]
+        p_log = np.log10(player[i])
+
+        t_low = 0
+        found = False
+        for j in range(t_inv_grid.size):
+            if t_inv_grid[j] > t_inv:
+                t_low = j
+                found = True
+        if not found:
+            t_low = 0
+        if t_low == t_inv_grid.size - 1:
+            t_low = t_inv_grid.size - 2
+        t_hi = t_low + 1
+
+        p_low = 0
+        found = False
+        for j in range(p_log_grid.size):
+            if p_log_grid[j] <= p_log:
+                p_low = j
+                found = True
+        if not found:
+            p_low = 0
+
+        max_avail_p = p_low
+        hi_limit = nc_p[t_hi] - 3
+        if hi_limit < max_avail_p:
+            max_avail_p = hi_limit
+        if max_avail_p < 0:
+            max_avail_p = 0
+        p_low = max_avail_p
+        p_hi = p_low + 1
+
+        t_inv_low = t_inv_grid[t_low]
+        t_inv_hi = t_inv_grid[t_hi]
+        p_log_low = p_log_grid[p_low]
+        p_log_hi = p_log_grid[p_hi]
+
+        row_low_low[i] = temp_row_offsets[t_low] + p_low
+        row_hi_low[i] = temp_row_offsets[t_hi] + p_low
+        row_low_hi[i] = temp_row_offsets[t_low] + p_hi
+        row_hi_hi[i] = temp_row_offsets[t_hi] + p_hi
+
+        t_interp[i] = (t_inv - t_inv_low) / (t_inv_hi - t_inv_low)
+        p_interp[i] = (p_log - p_log_low) / (p_log_hi - p_log_low)
+
+    return t_interp, p_interp, row_low_low, row_hi_low, row_low_hi, row_hi_hi
+
+
+@jit(nopython=True, cache=True)
+def _find_nearest_pt_rows_hdf5(player, tlayer, pt_pressures, pt_temperatures, pt_ids):
+    nlayer = tlayer.size
+    row_indices = np.empty(nlayer, dtype=np.int64)
+    ptid_indices = np.empty(nlayer, dtype=np.int64)
+    for i in range(nlayer):
+        player_log = np.log(player[i])
+        best_row = 0
+        best_metric = math.hypot(np.log(pt_pressures[0]) - player_log, pt_temperatures[0] - tlayer[i])
+        for j in range(1, pt_pressures.size):
+            metric = math.hypot(np.log(pt_pressures[j]) - player_log, pt_temperatures[j] - tlayer[i])
+            if metric < best_metric:
+                best_metric = metric
+                best_row = j
+        row_indices[i] = best_row
+        ptid_indices[i] = pt_ids[best_row]
+    return row_indices, ptid_indices
+
+
+@jit(nopython=True, cache=True)
+def _find_nearest_temperature_rows_hdf5(tlayer, cia_temps):
+    nlayer = tlayer.size
+    row_indices = np.empty(nlayer, dtype=np.int64)
+    for i in range(nlayer):
+        best_row = 0
+        best_metric = abs(cia_temps[0] - tlayer[i])
+        for j in range(1, cia_temps.size):
+            metric = abs(cia_temps[j] - tlayer[i])
+            if metric < best_metric:
+                best_metric = metric
+                best_row = j
+        row_indices[i] = best_row
+    return row_indices
+
+
+@jit(nopython=True, cache=True)
+def _fill_hdf5_nearest_block(output, block, local_rows, scale):
+    nlayer, nwno = output.shape
+    for i in range(nlayer):
+        row = local_rows[i]
+        for j in range(nwno):
+            output[i, j] = scale * block[row, j]
+
+
 class RetrieveOpacitiesHDF5(RetrieveOpacities):
     """
     HDF5 reader for resampled opacity databases.
@@ -2569,6 +2696,12 @@ class RetrieveOpacitiesHDF5(RetrieveOpacities):
         self.p_log_grid = log10(self.pressures)
         self.temps = df['temperature'].unique()
         self.t_inv_grid = 1/self.temps
+        self._pt_ids = np.asarray(pt_pairs[:, 0], dtype=np.int64)
+        self._pt_pressures = np.asarray(pt_pairs[:, 1], dtype=np.float64)
+        self._pt_temperatures = np.asarray(pt_pairs[:, 2], dtype=np.float64)
+        self._temp_row_offsets = np.zeros(self.nc_p.size, dtype=np.int64)
+        if self.nc_p.size > 1:
+            self._temp_row_offsets[1:] = np.cumsum(self.nc_p[:-1], dtype=np.int64)
 
         native_wno = np.asarray(self._header["wavenumber_grid"][:], dtype=np.float64)
         resampled_wno = native_wno[::self.resample]
@@ -2598,6 +2731,10 @@ class RetrieveOpacitiesHDF5(RetrieveOpacities):
         self._continuum_temp_to_row = {
             float(temp): idx for idx, temp in enumerate(self.cia_temps.tolist())
         }
+        self._molecular_opa = {}
+        self._continuum_opa = {}
+        self.loaded_molecules = None
+        self.loaded_continuum = None
 
     def preload_opacities(self,molecules,p_range,t_range):
         self.preload=True
@@ -2606,69 +2743,119 @@ class RetrieveOpacitiesHDF5(RetrieveOpacities):
                            (ind_pt[:,1] <p_range[1])))]
         ind_pt = ind_pt[np.where(((ind_pt[:,2] >t_range[0]) &
                            (ind_pt[:,2] <t_range[1])))][:,0]
-        if self.query_method == 'linear':
-            self.loaded_molecules = self._get_query_molecular(ind_pt,molecules,None, decode_log=True)
-        else:
-            self.loaded_molecules = self._get_query_molecular(ind_pt,molecules,None)
+        row_indices = np.array(
+            [self._ptid_to_row[int(ptid)] for ptid in np.asarray(ind_pt, dtype=np.int64)],
+            dtype=np.int64,
+        )
+        self.loaded_molecules = self._load_molecular_blocks(
+            row_indices,
+            molecules,
+            decode_log=(self.query_method == 'linear'),
+        )
 
-        tcia = self.cia_temps[np.where(((self.cia_temps > t_range[0]) &
-                                        (self.cia_temps < t_range[1])
-                ))]
+        continuum_rows = np.where(
+            ((self.cia_temps > t_range[0]) & (self.cia_temps < t_range[1]))
+        )[0]
+        self.loaded_continuum = self._load_continuum_blocks(continuum_rows, self.avail_continuum)
 
-        cia_mol = self.avail_continuum
-        self.loaded_continuum = self._get_query_continuum(tcia,cia_mol,None)
+    def _prepare_output_buffers(self, molecules, cia_molecules, nlayer):
+        continuum_keys = [key[0] + key[1] for key in cia_molecules]
+        self.molecular_opa = self._reuse_or_allocate_output_dict(
+            getattr(self, "molecular_opa", None),
+            molecules,
+            nlayer,
+        )
+        self.continuum_opa = self._reuse_or_allocate_output_dict(
+            getattr(self, "continuum_opa", None),
+            continuum_keys,
+            nlayer,
+        )
 
-    def _get_query_continuum(self, tcia, cia_mol, cur):
-        data = {}
-        requested_temps = sorted({float(t) for t in np.asarray(tcia, dtype=np.float64).tolist()})
-        for molecule in cia_mol:
-            if molecule not in self._continuum_group:
-                raise Exception(f"Continuum species {molecule} not found in HDF5 opacity file")
-            dataset = self._continuum_group[molecule]
-            row_pairs = sorted(
-                (self._continuum_temp_to_row[float(temp)], float(temp))
-                for temp in requested_temps
-            )
-            row_indices = [row_index for row_index, _ in row_pairs]
-            block = self._decode_dataset_rows(
-                dataset,
-                row_indices,
-                self._default_continuum_storage_format,
-            )
-            for i_row, (_, temp_value) in enumerate(row_pairs):
-                data[molecule+'_'+str(temp_value)] = block[i_row]
-        return data
+    def _reuse_or_allocate_output_dict(self, existing, keys, nlayer):
+        shape = (nlayer, self.nwno)
+        if existing is None:
+            existing = {}
+        if list(existing.keys()) != list(keys):
+            return {key: np.empty(shape, dtype=np.float64) for key in keys}
+        for key in keys:
+            arr = existing.get(key)
+            if arr is None or arr.shape != shape or arr.dtype != np.float64:
+                return {key: np.empty(shape, dtype=np.float64) for key in keys}
+        return existing
 
-    def _get_query_molecular(self,ind_pt,molecules,cur, decode_log=False):
-        data = {}
-        requested_ptids = sorted({int(ptid) for ptid in np.asarray(ind_pt).tolist()})
+    def _build_row_lookup(self, row_indices, total_rows):
+        requested_rows = np.unique(np.asarray(row_indices, dtype=np.int64))
+        row_lookup = np.full(total_rows, -1, dtype=np.int64)
+        row_lookup[requested_rows] = np.arange(requested_rows.size, dtype=np.int64)
+        return requested_rows, row_lookup
+
+    def _load_molecular_blocks(self, row_indices, molecules, decode_log=False):
+        requested_rows, row_lookup = self._build_row_lookup(row_indices, self._pt_ids.size)
+        dense_blocks = {}
         for molecule in molecules:
             if molecule not in self._molecular_group:
                 raise Exception(f"Molecule {molecule} not found in HDF5 opacity file")
             dataset = self._molecular_group[molecule]
-            row_pairs = sorted(
-                (self._ptid_to_row[int(ptid)], int(ptid))
-                for ptid in requested_ptids
-            )
-            row_indices = [row_index for row_index, _ in row_pairs]
             if decode_log:
-                # The interpolated path operates in log-space, so keep HDF5
-                # molecular opacities in log10 form here to avoid redundant
-                # linear->log10 conversions in the hot interpolation loop.
-                block = self._decode_dataset_rows_log(
+                dense_blocks[molecule] = self._decode_dataset_rows_log(
                     dataset,
-                    row_indices,
+                    requested_rows,
                     self._default_molecular_storage_format,
                 )
             else:
-                block = self._decode_dataset_rows(
+                dense_blocks[molecule] = self._decode_dataset_rows(
                     dataset,
-                    row_indices,
+                    requested_rows,
                     self._default_molecular_storage_format,
                 )
-            for i_row, (_, ptid_value) in enumerate(row_pairs):
-                data[molecule+'_'+str(ptid_value)] = block[i_row]
-        return data
+        return dense_blocks, row_lookup
+
+    def _load_continuum_blocks(self, row_indices, continuum_species):
+        requested_rows, row_lookup = self._build_row_lookup(row_indices, self.cia_temps.size)
+        dense_blocks = {}
+        for molecule in continuum_species:
+            if molecule not in self._continuum_group:
+                raise Exception(f"Continuum species {molecule} not found in HDF5 opacity file")
+            dense_blocks[molecule] = self._decode_dataset_rows(
+                self._continuum_group[molecule],
+                requested_rows,
+                self._default_continuum_storage_format,
+            )
+        return dense_blocks, row_lookup
+
+    def _dense_cache_covers(self, loaded, names, row_indices):
+        if loaded is None:
+            return False
+        dense_blocks, row_lookup = loaded
+        for name in names:
+            if name not in dense_blocks:
+                return False
+        row_indices = np.asarray(row_indices, dtype=np.int64)
+        if row_indices.size == 0:
+            return True
+        if row_lookup.shape[0] <= int(np.max(row_indices)):
+            return False
+        return np.all(row_lookup[row_indices] >= 0)
+
+    def _get_molecular_blocks(self, row_indices, molecules, decode_log=False):
+        if self.preload and self._dense_cache_covers(self.loaded_molecules, molecules, row_indices):
+            return self.loaded_molecules
+        return self._load_molecular_blocks(row_indices, molecules, decode_log=decode_log)
+
+    def _get_continuum_blocks(self, row_indices, continuum_species):
+        if self.preload and self._dense_cache_covers(self.loaded_continuum, continuum_species, row_indices):
+            return self.loaded_continuum
+        return self._load_continuum_blocks(row_indices, continuum_species)
+
+    def _prepare_linear_pt_state(self, tlayer, player):
+        return _find_needed_pts_hdf5(
+            np.asarray(tlayer, dtype=np.float64),
+            np.asarray(player, dtype=np.float64),
+            np.asarray(self.t_inv_grid, dtype=np.float64),
+            np.asarray(self.p_log_grid, dtype=np.float64),
+            np.asarray(self.nc_p, dtype=np.int64),
+            np.asarray(self._temp_row_offsets, dtype=np.int64),
+        )
 
     def get_opacities(self, atmosphere, exclude_mol=1):
         nlayer = atmosphere.c.nlayer
@@ -2677,45 +2864,55 @@ class RetrieveOpacitiesHDF5(RetrieveOpacities):
         molecules = atmosphere.molecules
         cia_molecules = atmosphere.continuum_molecules
 
-        self.molecular_opa = {key:np.zeros((nlayer, self.nwno)) for key in molecules}
-        self.continuum_opa = {key[0]+key[1]:np.zeros((nlayer, self.nwno)) for key in cia_molecules}
+        self._prepare_output_buffers(molecules, cia_molecules, nlayer)
 
-        t_interp , p_interp, i_t_low_p_low, i_t_hi_p_low, i_t_low_p_hi, i_t_hi_p_hi = self.find_needed_pts(tlayer,player)
-        ind_pt = 1+np.unique(np.concatenate([i_t_low_p_low, i_t_hi_p_low, i_t_low_p_hi, i_t_hi_p_hi]))
-        atmosphere.layer['pt_opa_index'] = ind_pt
+        t_interp, p_interp, row_low_low, row_hi_low, row_low_hi, row_hi_hi = self._prepare_linear_pt_state(
+            tlayer,
+            player,
+        )
+        required_rows = np.unique(
+            np.concatenate([row_low_low, row_hi_low, row_low_hi, row_hi_hi])
+        )
+        atmosphere.layer['pt_opa_index'] = (1 + required_rows).tolist()
 
-        if self.preload:
-            data = self.loaded_molecules
-        else:
-            data = self._get_query_molecular(ind_pt,molecules,None, decode_log=True)
+        dense_blocks, row_lookup = self._get_molecular_blocks(required_rows, molecules, decode_log=True)
 
-        for i in self.molecular_opa.keys():
-            fac = 0 if is_opacity_excluded(exclude_mol, i, 'line') else 1
-            for ind in range(nlayer):
-                # HDF5 linear interpolation is intentionally done in log-space
-                # for speed: the datasets are already stored as log10 opacity, so
-                # we interpolate those values directly and exponentiate once.
-                log_abunds1 = data[i+'_'+str(1+i_t_low_p_low[ind])]
-                log_abunds2 = data[i+'_'+str(1+i_t_hi_p_low[ind])]
-                log_abunds3 = data[i+'_'+str(1+i_t_hi_p_hi[ind])]
-                log_abunds4 = data[i+'_'+str(1+i_t_low_p_hi[ind])]
-                cx = 10**(((1-t_interp[ind])* (1-p_interp[ind]) * log_abunds1) +
-                     ((t_interp[ind])  * (1-p_interp[ind]) * log_abunds2) +
-                     ((t_interp[ind])  * (p_interp[ind])   * log_abunds3) +
-                     ((1-t_interp[ind])* (p_interp[ind])   * log_abunds4) )
-                self.molecular_opa[i][ind, :] = fac*cx*6.02214086e+23
+        local_low_low = row_lookup[row_low_low]
+        local_hi_low = row_lookup[row_hi_low]
+        local_low_hi = row_lookup[row_low_hi]
+        local_hi_hi = row_lookup[row_hi_hi]
 
-        tcia = [np.unique(self.cia_temps)[find_nearest(np.unique(self.cia_temps),i)] for i in tlayer]
-        cia_mol = list(self.continuum_opa.keys())
+        for molecule in molecules:
+            fac = 0 if is_opacity_excluded(exclude_mol, molecule, 'line') else 1
+            # The HDF5 linear path stays entirely in log-space until the final
+            # write into the reusable output buffer, which removes redundant
+            # decode/re-encode work and keeps temporary memory flat.
+            _interpolate_hdf5_log_opacity(
+                self.molecular_opa[molecule],
+                dense_blocks[molecule],
+                local_low_low,
+                local_hi_low,
+                local_hi_hi,
+                local_low_hi,
+                t_interp,
+                p_interp,
+                fac * 6.02214086e+23,
+            )
 
-        if self.preload:
-            data = self.loaded_continuum
-        else:
-            data = self._get_query_continuum(tcia, cia_mol, None)
-
-        for i in self.continuum_opa.keys():
-            for j,ind in zip(tcia,range(nlayer)):
-                self.continuum_opa[i][ind,:] = data[i+'_'+str(j)]
+        continuum_species = list(self.continuum_opa.keys())
+        continuum_rows = _find_nearest_temperature_rows_hdf5(
+            np.asarray(tlayer, dtype=np.float64),
+            np.asarray(self.cia_temps, dtype=np.float64),
+        )
+        dense_continuum, continuum_lookup = self._get_continuum_blocks(continuum_rows, continuum_species)
+        continuum_local_rows = continuum_lookup[continuum_rows]
+        for molecule in continuum_species:
+            _fill_hdf5_nearest_block(
+                self.continuum_opa[molecule],
+                dense_continuum[molecule],
+                continuum_local_rows,
+                1.0,
+            )
 
     def get_opacities_nearest(self, atmosphere, exclude_mol=1):
         nlayer =atmosphere.c.nlayer
@@ -2725,35 +2922,44 @@ class RetrieveOpacitiesHDF5(RetrieveOpacities):
         molecules = atmosphere.molecules
         cia_molecules = atmosphere.continuum_molecules
 
-        self.molecular_opa = {key:np.zeros((nlayer, self.nwno)) for key in molecules}
-        self.continuum_opa = {key[0]+key[1]:np.zeros((nlayer, self.nwno)) for key in cia_molecules}
+        self._prepare_output_buffers(molecules, cia_molecules, nlayer)
 
-        ind_pt=[min(self.pt_pairs,
-            key=lambda c: math.hypot(np.log(c[1])- np.log(coordinate[0]), c[2]-coordinate[1]))[0]
-                for coordinate in  zip(player,tlayer)]
-        atmosphere.layer['pt_opa_index'] = ind_pt
+        nearest_rows, nearest_ptids = _find_nearest_pt_rows_hdf5(
+            np.asarray(player, dtype=np.float64),
+            np.asarray(tlayer, dtype=np.float64),
+            np.asarray(self._pt_pressures, dtype=np.float64),
+            np.asarray(self._pt_temperatures, dtype=np.float64),
+            np.asarray(self._pt_ids, dtype=np.int64),
+        )
+        atmosphere.layer['pt_opa_index'] = nearest_ptids.tolist()
 
-        if self.preload:
-            data = self.loaded_molecules
-        else:
-            data = self._get_query_molecular(ind_pt,molecules,None)
+        dense_blocks, row_lookup = self._get_molecular_blocks(nearest_rows, molecules, decode_log=False)
+        local_rows = row_lookup[nearest_rows]
 
-        for i in self.molecular_opa.keys():
-            fac = 0 if is_opacity_excluded(exclude_mol, i, 'line') else 1
-            for j,ind in zip(ind_pt,range(nlayer)):
-                self.molecular_opa[i][ind, :] = fac*data[i+'_'+str(j)]*6.02214086e+23
+        for molecule in molecules:
+            fac = 0 if is_opacity_excluded(exclude_mol, molecule, 'line') else 1
+            _fill_hdf5_nearest_block(
+                self.molecular_opa[molecule],
+                dense_blocks[molecule],
+                local_rows,
+                fac * 6.02214086e+23,
+            )
 
-        tcia = [np.unique(self.cia_temps)[find_nearest(np.unique(self.cia_temps),i)] for i in tlayer]
-        cia_mol = list(self.continuum_opa.keys())
+        continuum_species = list(self.continuum_opa.keys())
+        continuum_rows = _find_nearest_temperature_rows_hdf5(
+            np.asarray(tlayer, dtype=np.float64),
+            np.asarray(self.cia_temps, dtype=np.float64),
+        )
+        dense_continuum, continuum_lookup = self._get_continuum_blocks(continuum_rows, continuum_species)
+        continuum_local_rows = continuum_lookup[continuum_rows]
 
-        if self.preload:
-            data = self.loaded_continuum
-        else:
-            data = self._get_query_continuum(tcia, cia_mol, None)
-
-        for i in self.continuum_opa.keys():
-            for j,ind in zip(tcia,range(nlayer)):
-                self.continuum_opa[i][ind,:] = data[i+'_'+str(j)]
+        for molecule in continuum_species:
+            _fill_hdf5_nearest_block(
+                self.continuum_opa[molecule],
+                dense_continuum[molecule],
+                continuum_local_rows,
+                1.0,
+            )
 
 def adapt_array(arr):
     """needed to interpret bytes to array"""

--- a/picaso/optics.py
+++ b/picaso/optics.py
@@ -2162,6 +2162,8 @@ class RetrieveOpacities():
         """
         Get queried continuum 
         """
+        tcia = tuple(float(i) for i in np.asarray(tcia, dtype=np.float64).tolist())
+        cia_mol = tuple(str(i) for i in cia_mol)
         #if user only runs a single molecule or temperature
         #if len(tcia) ==1: 
         #    query_temp = """AND temperature= '{}' """.format(str(tcia[0]))
@@ -2188,7 +2190,7 @@ class RetrieveOpacities():
             query_mol = "WHERE molecule IN ({})".format(','.join(['?'] * len(cia_mol)))
 
 
-        query_params = tuple(cia_mol) + tuple(tcia)
+        query_params = cia_mol + tcia
 
         cur.execute("""
             SELECT molecule, temperature, opacity 
@@ -2205,6 +2207,8 @@ class RetrieveOpacities():
         """
         submits query
         """
+        ind_pt = tuple(int(i) for i in np.asarray(ind_pt).tolist())
+        molecules = tuple(str(i) for i in molecules)
         #query molecular opacities from sqlite3
         #if len(molecules) ==1: 
         #    query_mol = """WHERE molecule= '{}' """.format(str(molecules[0]))
@@ -2223,7 +2227,7 @@ class RetrieveOpacities():
 
         query_pt = "AND ptid IN ({})".format(','.join(['?'] * len(ind_pt)))
 
-        query_params = tuple(molecules) + tuple(ind_pt)
+        query_params = molecules + ind_pt
 
         cur.execute("""SELECT molecule,ptid,opacity 
                     FROM molecular 
@@ -2396,6 +2400,360 @@ class RetrieveOpacities():
             all_shifted_spec[:,i] = shifted_flux/unshifted
 
         self.raman_stellar_shifts = all_shifted_spec
+
+
+def _decode_hdf5_string(value):
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    if isinstance(value, np.ndarray):
+        if value.shape == ():
+            return _decode_hdf5_string(value.item())
+        return [_decode_hdf5_string(i) for i in value.tolist()]
+    return str(value)
+
+
+def _decode_hdf5_opacity_block(raw_block, storage_format, y_min=None, y_max=None):
+    storage_format = _decode_hdf5_string(storage_format)
+    if storage_format == 'log10_float32':
+        return 10**(np.asarray(raw_block, dtype=np.float64))
+    if storage_format == 'log10_uint16':
+        if y_min is None or y_max is None:
+            raise Exception("log10_uint16 datasets require scalar y_min and y_max attributes")
+        y_min = np.asarray(y_min)
+        y_max = np.asarray(y_max)
+        if y_min.shape != () or y_max.shape != ():
+            raise Exception("log10_uint16 datasets require scalar y_min and y_max attributes")
+        y_min = float(y_min)
+        y_max = float(y_max)
+        if y_max == y_min:
+            log_block = np.zeros(np.asarray(raw_block).shape, dtype=np.float64) + y_min
+        else:
+            log_block = y_min + (y_max - y_min) * (
+                np.asarray(raw_block, dtype=np.float64) / 65535.0
+            )
+        return 10**log_block
+    raise Exception(
+        f"Do not recognize HDF5 opacity storage format: {storage_format}. "
+        "Supported formats are log10_uint16 and log10_float32."
+    )
+
+
+def _decode_hdf5_log_block(raw_block, storage_format, y_min=None, y_max=None):
+    storage_format = _decode_hdf5_string(storage_format)
+    if storage_format == 'log10_float32':
+        return np.asarray(raw_block, dtype=np.float64)
+    if storage_format == 'log10_uint16':
+        if y_min is None or y_max is None:
+            raise Exception("log10_uint16 datasets require scalar y_min and y_max attributes")
+        y_min = np.asarray(y_min)
+        y_max = np.asarray(y_max)
+        if y_min.shape != () or y_max.shape != ():
+            raise Exception("log10_uint16 datasets require scalar y_min and y_max attributes")
+        y_min = float(y_min)
+        y_max = float(y_max)
+        if y_max == y_min:
+            return np.zeros(np.asarray(raw_block).shape, dtype=np.float64) + y_min
+        return y_min + (y_max - y_min) * (
+            np.asarray(raw_block, dtype=np.float64) / 65535.0
+        )
+    raise Exception(
+        f"Do not recognize HDF5 opacity storage format: {storage_format}. "
+        "Supported formats are log10_uint16 and log10_float32."
+    )
+
+
+class RetrieveOpacitiesHDF5(RetrieveOpacities):
+    """
+    HDF5 reader for resampled opacity databases.
+    """
+    def __init__(self, db_filename, raman_data, wave_range=None, location='local', resample=1,
+        query_method='nearest'):
+
+        self.ngauss = 1
+        self.gauss_wts = np.array([1])
+        self.db_filename = db_filename
+        self._h5 = h5py.File(self.db_filename, "r")
+
+        try:
+            self._header = self._h5["header"]
+            self._molecular_group = self._h5["molecular"]
+            self._continuum_group = self._h5["continuum"]
+        except KeyError as exc:
+            self.close()
+            raise Exception(
+                f"The HDF5 opacity file does not match the expected resampled layout: missing {exc}"
+            )
+
+        self.get_available_data(wave_range, resample)
+
+        self.raman_db = pd.read_csv(
+            raman_data,
+            sep=r'\s+',
+            skiprows=16,
+            header=None,
+            names=['ji','jf','vf','c','deltanu'],
+        )
+
+        self.get_available_rayleigh()
+        self.preload = False
+        self.query_method = query_method
+
+        if query_method == 'nearest':
+            self.get_opacities = self.get_opacities_nearest
+        elif query_method == 'linear':
+            self.get_opacities = self.__class__.get_opacities.__get__(self)
+        else:
+            self.close()
+            raise Exception(
+                f'Do not recognize query method for opacities: {query_method}. Options are nearest or linear'
+            )
+
+    def close(self):
+        h5 = getattr(self, "_h5", None)
+        if h5 is not None:
+            try:
+                h5.close()
+            except Exception:
+                pass
+            self._h5 = None
+
+    def __del__(self):
+        self.close()
+
+    def _get_storage_format(self, dataset, default_value):
+        raw = dataset.attrs.get("storage_format", default_value)
+        return _decode_hdf5_string(raw)
+
+    def _decode_dataset_rows(self, dataset, row_indices, default_storage_format):
+        row_indices = np.asarray(row_indices, dtype=np.int64)
+        raw_block = dataset[row_indices, self._dataset_wave_slice]
+        storage_format = self._get_storage_format(dataset, default_storage_format)
+        if storage_format == 'log10_uint16':
+            decoded = _decode_hdf5_opacity_block(
+                raw_block,
+                storage_format,
+                y_min=dataset.attrs.get("y_min"),
+                y_max=dataset.attrs.get("y_max"),
+            )
+        else:
+            decoded = _decode_hdf5_opacity_block(raw_block, storage_format)
+        return np.asarray(decoded, dtype=np.float64)
+
+    def _decode_dataset_rows_log(self, dataset, row_indices, default_storage_format):
+        row_indices = np.asarray(row_indices, dtype=np.int64)
+        raw_block = dataset[row_indices, self._dataset_wave_slice]
+        storage_format = self._get_storage_format(dataset, default_storage_format)
+        decoded = _decode_hdf5_log_block(
+            raw_block,
+            storage_format,
+            y_min=dataset.attrs.get("y_min"),
+            y_max=dataset.attrs.get("y_max"),
+        )
+        return np.asarray(decoded, dtype=np.float64)
+
+    def get_available_data(self, wave_range, resample):
+        self.resample = resample
+
+        self.cia_temps = np.asarray(self._header["continuum_temperatures"][:], dtype=np.float64)
+        self.avail_continuum = list(_decode_hdf5_string(self._header["continuum_molecules"][:]))
+        self.molecules = list(_decode_hdf5_string(self._header["molecules"][:]))
+
+        pt_pairs = np.asarray(self._header["pt_pairs"][:], dtype=np.float64)
+        if pt_pairs.ndim != 2 or pt_pairs.shape[1] < 3:
+            raise Exception("HDF5 header/pt_pairs must be a 2D array with columns ptid, pressure, temperature")
+
+        self.pt_pairs = [(int(row[0]), float(row[1]), float(row[2])) for row in pt_pairs]
+        df = pd.DataFrame(self.pt_pairs, columns=['ptid','pressure','temperature'])
+        self.nc_p = df.groupby('temperature').size().values
+        self.pressures = df['pressure'].unique()
+        self.p_log_grid = log10(self.pressures)
+        self.temps = df['temperature'].unique()
+        self.t_inv_grid = 1/self.temps
+
+        native_wno = np.asarray(self._header["wavenumber_grid"][:], dtype=np.float64)
+        resampled_wno = native_wno[::self.resample]
+        resampled_wave = 1e4/resampled_wno
+        if wave_range is None:
+            selected_resampled_indices = np.arange(resampled_wno.size, dtype=np.int64)
+        else:
+            selected_resampled_indices = np.where(
+                ((resampled_wave > min(wave_range)) & (resampled_wave < max(wave_range)))
+            )[0]
+        if selected_resampled_indices.size == 0:
+            raise Exception("The requested wave_range does not overlap the opacity grid")
+
+        start = int(selected_resampled_indices[0]) * self.resample
+        stop = (int(selected_resampled_indices[-1]) + 1) * self.resample
+        self._dataset_wave_slice = slice(start, stop, self.resample)
+
+        self.wno = resampled_wno[selected_resampled_indices]
+        self.wave = resampled_wave[selected_resampled_indices]
+        self.nwno = np.size(self.wno)
+
+        self._default_molecular_storage_format = _decode_hdf5_string(self._header["storage_format"][()])
+        self._default_continuum_storage_format = _decode_hdf5_string(
+            self._header["continuum_storage_format"][()]
+        )
+        self._ptid_to_row = {int(row[0]): idx for idx, row in enumerate(self.pt_pairs)}
+        self._continuum_temp_to_row = {
+            float(temp): idx for idx, temp in enumerate(self.cia_temps.tolist())
+        }
+
+    def preload_opacities(self,molecules,p_range,t_range):
+        self.preload=True
+        ind_pt = np.array(self.pt_pairs)
+        ind_pt = ind_pt[np.where(((ind_pt[:,1] >p_range[0]) &
+                           (ind_pt[:,1] <p_range[1])))]
+        ind_pt = ind_pt[np.where(((ind_pt[:,2] >t_range[0]) &
+                           (ind_pt[:,2] <t_range[1])))][:,0]
+        if self.query_method == 'linear':
+            self.loaded_molecules = self._get_query_molecular(ind_pt,molecules,None, decode_log=True)
+        else:
+            self.loaded_molecules = self._get_query_molecular(ind_pt,molecules,None)
+
+        tcia = self.cia_temps[np.where(((self.cia_temps > t_range[0]) &
+                                        (self.cia_temps < t_range[1])
+                ))]
+
+        cia_mol = self.avail_continuum
+        self.loaded_continuum = self._get_query_continuum(tcia,cia_mol,None)
+
+    def _get_query_continuum(self, tcia, cia_mol, cur):
+        data = {}
+        requested_temps = sorted({float(t) for t in np.asarray(tcia, dtype=np.float64).tolist()})
+        for molecule in cia_mol:
+            if molecule not in self._continuum_group:
+                raise Exception(f"Continuum species {molecule} not found in HDF5 opacity file")
+            dataset = self._continuum_group[molecule]
+            row_pairs = sorted(
+                (self._continuum_temp_to_row[float(temp)], float(temp))
+                for temp in requested_temps
+            )
+            row_indices = [row_index for row_index, _ in row_pairs]
+            block = self._decode_dataset_rows(
+                dataset,
+                row_indices,
+                self._default_continuum_storage_format,
+            )
+            for i_row, (_, temp_value) in enumerate(row_pairs):
+                data[molecule+'_'+str(temp_value)] = block[i_row]
+        return data
+
+    def _get_query_molecular(self,ind_pt,molecules,cur, decode_log=False):
+        data = {}
+        requested_ptids = sorted({int(ptid) for ptid in np.asarray(ind_pt).tolist()})
+        for molecule in molecules:
+            if molecule not in self._molecular_group:
+                raise Exception(f"Molecule {molecule} not found in HDF5 opacity file")
+            dataset = self._molecular_group[molecule]
+            row_pairs = sorted(
+                (self._ptid_to_row[int(ptid)], int(ptid))
+                for ptid in requested_ptids
+            )
+            row_indices = [row_index for row_index, _ in row_pairs]
+            if decode_log:
+                # The interpolated path operates in log-space, so keep HDF5
+                # molecular opacities in log10 form here to avoid redundant
+                # linear->log10 conversions in the hot interpolation loop.
+                block = self._decode_dataset_rows_log(
+                    dataset,
+                    row_indices,
+                    self._default_molecular_storage_format,
+                )
+            else:
+                block = self._decode_dataset_rows(
+                    dataset,
+                    row_indices,
+                    self._default_molecular_storage_format,
+                )
+            for i_row, (_, ptid_value) in enumerate(row_pairs):
+                data[molecule+'_'+str(ptid_value)] = block[i_row]
+        return data
+
+    def get_opacities(self, atmosphere, exclude_mol=1):
+        nlayer = atmosphere.c.nlayer
+        tlayer = atmosphere.layer['temperature']
+        player = atmosphere.layer['pressure']/atmosphere.c.pconv
+        molecules = atmosphere.molecules
+        cia_molecules = atmosphere.continuum_molecules
+
+        self.molecular_opa = {key:np.zeros((nlayer, self.nwno)) for key in molecules}
+        self.continuum_opa = {key[0]+key[1]:np.zeros((nlayer, self.nwno)) for key in cia_molecules}
+
+        t_interp , p_interp, i_t_low_p_low, i_t_hi_p_low, i_t_low_p_hi, i_t_hi_p_hi = self.find_needed_pts(tlayer,player)
+        ind_pt = 1+np.unique(np.concatenate([i_t_low_p_low, i_t_hi_p_low, i_t_low_p_hi, i_t_hi_p_hi]))
+        atmosphere.layer['pt_opa_index'] = ind_pt
+
+        if self.preload:
+            data = self.loaded_molecules
+        else:
+            data = self._get_query_molecular(ind_pt,molecules,None, decode_log=True)
+
+        for i in self.molecular_opa.keys():
+            fac = 0 if is_opacity_excluded(exclude_mol, i, 'line') else 1
+            for ind in range(nlayer):
+                # HDF5 linear interpolation is intentionally done in log-space
+                # for speed: the datasets are already stored as log10 opacity, so
+                # we interpolate those values directly and exponentiate once.
+                log_abunds1 = data[i+'_'+str(1+i_t_low_p_low[ind])]
+                log_abunds2 = data[i+'_'+str(1+i_t_hi_p_low[ind])]
+                log_abunds3 = data[i+'_'+str(1+i_t_hi_p_hi[ind])]
+                log_abunds4 = data[i+'_'+str(1+i_t_low_p_hi[ind])]
+                cx = 10**(((1-t_interp[ind])* (1-p_interp[ind]) * log_abunds1) +
+                     ((t_interp[ind])  * (1-p_interp[ind]) * log_abunds2) +
+                     ((t_interp[ind])  * (p_interp[ind])   * log_abunds3) +
+                     ((1-t_interp[ind])* (p_interp[ind])   * log_abunds4) )
+                self.molecular_opa[i][ind, :] = fac*cx*6.02214086e+23
+
+        tcia = [np.unique(self.cia_temps)[find_nearest(np.unique(self.cia_temps),i)] for i in tlayer]
+        cia_mol = list(self.continuum_opa.keys())
+
+        if self.preload:
+            data = self.loaded_continuum
+        else:
+            data = self._get_query_continuum(tcia, cia_mol, None)
+
+        for i in self.continuum_opa.keys():
+            for j,ind in zip(tcia,range(nlayer)):
+                self.continuum_opa[i][ind,:] = data[i+'_'+str(j)]
+
+    def get_opacities_nearest(self, atmosphere, exclude_mol=1):
+        nlayer =atmosphere.c.nlayer
+        tlayer =atmosphere.layer['temperature']
+        player = atmosphere.layer['pressure']/atmosphere.c.pconv
+
+        molecules = atmosphere.molecules
+        cia_molecules = atmosphere.continuum_molecules
+
+        self.molecular_opa = {key:np.zeros((nlayer, self.nwno)) for key in molecules}
+        self.continuum_opa = {key[0]+key[1]:np.zeros((nlayer, self.nwno)) for key in cia_molecules}
+
+        ind_pt=[min(self.pt_pairs,
+            key=lambda c: math.hypot(np.log(c[1])- np.log(coordinate[0]), c[2]-coordinate[1]))[0]
+                for coordinate in  zip(player,tlayer)]
+        atmosphere.layer['pt_opa_index'] = ind_pt
+
+        if self.preload:
+            data = self.loaded_molecules
+        else:
+            data = self._get_query_molecular(ind_pt,molecules,None)
+
+        for i in self.molecular_opa.keys():
+            fac = 0 if is_opacity_excluded(exclude_mol, i, 'line') else 1
+            for j,ind in zip(ind_pt,range(nlayer)):
+                self.molecular_opa[i][ind, :] = fac*data[i+'_'+str(j)]*6.02214086e+23
+
+        tcia = [np.unique(self.cia_temps)[find_nearest(np.unique(self.cia_temps),i)] for i in tlayer]
+        cia_mol = list(self.continuum_opa.keys())
+
+        if self.preload:
+            data = self.loaded_continuum
+        else:
+            data = self._get_query_continuum(tcia, cia_mol, None)
+
+        for i in self.continuum_opa.keys():
+            for j,ind in zip(tcia,range(nlayer)):
+                self.continuum_opa[i][ind,:] = data[i+'_'+str(j)]
 
 def adapt_array(arr):
     """needed to interpret bytes to array"""


### PR DESCRIPTION
## Summary

This PR adds a HDF5 support for resampled opacity databases as an alternative to SQLite. There is overlap with this PR: https://github.com/natashabatalha/picaso/pull/360

The HDF5 files can store opacities in two different formats: `log10_uint16` and `log10_float32`. 

The `log10_uint16` approach saves log10 opacities using unsigned 16 bit integers as described in #397. When lzf + shuffle compression is used, this decreases resampled opacity file sizes by a factor of 10. The resulting spectra with the `log10_uint16`  are the same as those computed with a SQLite opacity DB to within a factor of < 0.04% in core tests (reflected + transmission + thermal). Also, the `log10_uint16` approach with compression is as fast or faster than SQLite (see benchmark below).

The `log10_float32` storage format is just log10 of opacity as a float32, which stores the opacity more accurately.

## What changed

- Added `RetrieveOpacitiesHDF5` and wired `opannection(...)` to dispatch to it automatically for `.h5` and `.hdf5` files.
- Added HDF5 resampled-opacity support for both `nearest` and `linear` query modes.
- Added support for HDF5 opacity storage formats:
  - `log10_uint16`
  - `log10_float32`
- Reworked the HDF5 reader to use dense row blocks, reusable output buffers, and compiled numeric kernels instead of the old string-keyed hot path.
- Added `convert_sqlite_to_hdf5(...)` to `picaso/opacity_factory.py` so users can convert a resampled SQLite opacity database directly into the HDF5 layout expected by PICASO.
- Added configurable molecular and continuum log floors, chunk sizing, and progress reporting to the conversion helper.
- Tightened SQLite query-parameter handling in `optics.py` so NumPy scalar values are converted to plain Python types before parameter binding.

## Validation

I have attached a test that I ran on my local machine. I run thermal + transmission + reflected light calculations of an Earth-like atmosphere with both an SQLite opacity DB and an HDF5 opacity DB with `log10_uint16` storage as well as lzf+shuffle compression. The results of the test are pasted below.

For `query_method = nearest`, the relative difference between spectra is often around ~1e-6 and at maximum ~4e-4. Runtimes for HDF5 are faster in all cases.

For `query_method = linear`, the relative difference is large because of a bug in the SQLite indexing as described in #398. A separate PR should fix this issue with SQLite because "fixing" the bug might break previous SQLite DBs and so choices must be made. When I fix the bug for my test opacity DB, then I get good agreement between the HDF5 and SQLite path for `query_method = linear`. The runtimes are faster for the HDF5 because I implemented numba-based linear interpolation.

[test.py](https://github.com/user-attachments/files/26761039/test.py)

```
query_method = nearest
calculation = transmission; wave_range = [1.0, 5.0]
Case SQLite warmup runtime: 0.33 s
Case SQLite steady-state runtime: 0.37 s
Case HDF5_I16 warmup runtime: 0.31 s
Case HDF5_I16 steady-state runtime: 0.28 s
HDF5 uint16 vs SQLite rprs2 relative difference stats
  p50 rel diff:  1.0e-08
  p75 rel diff:  1.9e-08
  p90 rel diff:  3.1e-08
  p99 rel diff:  7.4e-08
  p100 rel diff: 1.4e-07
calculation = reflected; wave_range = [0.2, 2.0]
Case SQLite warmup runtime: 2.19 s
Case SQLite steady-state runtime: 2.25 s
Case HDF5_I16 warmup runtime: 2.20 s
Case HDF5_I16 steady-state runtime: 2.11 s
HDF5 uint16 vs SQLite albedo relative difference stats
  p50 rel diff:  2.6e-06
  p75 rel diff:  9.4e-06
  p90 rel diff:  2.0e-05
  p99 rel diff:  1.2e-04
  p100 rel diff: 4.1e-04
calculation = thermal; wave_range = [3.0, 20.0]
Case SQLite warmup runtime: 0.86 s
Case SQLite steady-state runtime: 0.83 s
Case HDF5_I16 warmup runtime: 0.86 s
Case HDF5_I16 steady-state runtime: 0.80 s
HDF5 uint16 vs SQLite planet flux relative difference stats
  p50 rel diff:  2.1e-06
  p75 rel diff:  4.8e-06
  p90 rel diff:  8.7e-06
  p99 rel diff:  1.7e-05
  p100 rel diff: 2.6e-05

query_method = linear
calculation = transmission; wave_range = [1.0, 5.0]
Case SQLite warmup runtime: 0.73 s
Case SQLite steady-state runtime: 0.78 s
Case HDF5_I16 warmup runtime: 0.49 s
Case HDF5_I16 steady-state runtime: 0.45 s
HDF5 uint16 vs SQLite rprs2 relative difference stats
  p50 rel diff:  3.8e-04
  p75 rel diff:  6.8e-04
  p90 rel diff:  1.0e-03
  p99 rel diff:  1.3e-03
  p100 rel diff: 1.4e-03
calculation = reflected; wave_range = [0.2, 2.0]
Case SQLite warmup runtime: 2.80 s
Case SQLite steady-state runtime: 2.82 s
Case HDF5_I16 warmup runtime: 2.53 s
Case HDF5_I16 steady-state runtime: 2.36 s
HDF5 uint16 vs SQLite albedo relative difference stats
  p50 rel diff:  2.3e-04
  p75 rel diff:  6.4e-02
  p90 rel diff:  3.8e-01
  p99 rel diff:  1.8e+00
  p100 rel diff: 4.8e+00
calculation = thermal; wave_range = [3.0, 20.0]
Case SQLite warmup runtime: 1.41 s
Case SQLite steady-state runtime: 1.53 s
Case HDF5_I16 warmup runtime: 1.05 s
Case HDF5_I16 steady-state runtime: 1.01 s
HDF5 uint16 vs SQLite planet flux relative difference stats
  p50 rel diff:  1.0e-01
  p75 rel diff:  2.5e-01
  p90 rel diff:  3.3e-01
  p99 rel diff:  1.1e+00
  p100 rel diff: 1.8e+00
```