### PR TITLE
Fix GPU memory allocation and indexing bugs in CUDA kernels

### DIFF
--- a/picaso/fluxes_gpu.py
+++ b/picaso/fluxes_gpu.py
@@ -495,8 +495,7 @@ def get_reflected_1d(
             ctypes.c_double, # cos_theta
             ctypes.c_double, # b_top
             # ctypes.c_double, # surf_reflect
-            c_double_p,      # gweight
-            c_double_p,      # tweight
+            c_double_p,      # combined_weights
             c_void_p,      # test_out
             c_void_p,      # flux_minus_all_out
             c_void_p,      # flux_plus_all_out
@@ -536,10 +535,15 @@ def get_reflected_1d(
             float(toon_coefficients)
         )
 
-        ubar0_pointer = (ctypes.c_double*ubar0.size)(*ubar0)
-        ubar1_pointer = (ctypes.c_double*ubar1.size)(*ubar1)
-        gweight_pointer = (ctypes.c_double*gweight.size)(*gweight)
-        tweight_pointer = (ctypes.c_double*tweight.size)(*tweight)
+        ubar0_pointer = (ctypes.c_double*ubar0.size)(*ubar0.flatten())
+        ubar1_pointer = (ctypes.c_double*ubar1.size)(*ubar1.flatten())
+
+        # Pre-calculate combined weights for the disco integration
+        # gweight is ng, tweight is nt. ubar0/1 are (ng, nt) flattened.
+        # The loop in CUDA is over i_iter = 0 to ng*nt.
+        # We need weight[i_iter] = gweight[ig] * tweight[it]
+        weights = np.outer(gweight, tweight).flatten()
+        weights_pointer = (ctypes.c_double*weights.size)(*weights)
 
         flux_at_top  = cp.zeros(F0PI.size)
         flux_at_top_p   = ctypes.c_void_p(flux_at_top.data.ptr)
@@ -562,8 +566,7 @@ def get_reflected_1d(
             ctypes.c_double(cos_theta),
             ctypes.c_double(b_top),
             # ctypes.c_double(atm_surf_reflect),
-            gweight_pointer,
-            tweight_pointer,
+            weights_pointer,
             flux_at_top_p,
             flux_minus_all_out_p,
             flux_plus_all_out_p,

--- a/picaso/gpu/reflect_1d_kernel.cu
+++ b/picaso/gpu/reflect_1d_kernel.cu
@@ -255,19 +255,19 @@ __global__ void setup_tri_diag_last(
     double * __restrict__ C_odd_dev,
     double * __restrict__ D_odd_dev)
 {
-    int index = global_idx_1d();
-    int total = nlayer * nwno;
-    if (index >= total) return;
+    int index_wn = global_idx_1d();
+    if (index_wn >= nwno) return;
 
-    if ((index > (nlayer - 1) * nwno) && (index < nlayer * nwno)) {
-        int idx = index + nlayer * nwno;
-        A_odd_dev[idx] = e1_dev[index] - atm_surf_reflect_dev[index] * e3_dev[index];
-        B_odd_dev[idx] = e2_dev[index] - atm_surf_reflect_dev[index] * e4_dev[index];
-        C_odd_dev[idx] = 0.0;
-        D_odd_dev[idx] = b_surface_dev[index - (nlayer - 1) * nwno]
+    int index_layer = nlayer - 1;
+    int index = index_layer * nwno + index_wn;
+    int index_tri = (2 * nlayer - 1) * nwno + index_wn;
+
+    A_odd_dev[index_tri] = e1_dev[index] - atm_surf_reflect_dev[index_wn] * e3_dev[index];
+    B_odd_dev[index_tri] = e2_dev[index] - atm_surf_reflect_dev[index_wn] * e4_dev[index];
+    C_odd_dev[index_tri] = 0.0;
+    D_odd_dev[index_tri] = b_surface_dev[index_wn]
                          - c_plus_down_dev[index]
-                         + atm_surf_reflect_dev[index] * c_minus_down_dev[index];
-    }
+                         + atm_surf_reflect_dev[index_wn] * c_minus_down_dev[index];
 }
 
 
@@ -635,13 +635,13 @@ __global__ void calculate_xint(
 __global__ void compute_disco(
     double * __restrict__ albedo_dev,
     double * __restrict__ xint_dev,
-    double gweight, double tweight,
+    double weight,
     int nwno)
 {
     int index = global_idx_1d();
     if (index >= nwno) return;
 
-    albedo_dev[index] += xint_dev[index] * gweight * tweight;
+    albedo_dev[index] += xint_dev[index] * weight;
 }
 
 
@@ -977,6 +977,8 @@ extern "C" void get_reflected_1d_set_inputs(
 }
 
 
+extern "C" void get_reflected_1d_free();
+
 extern "C" void get_reflected_1d_allocate_buffers(
     int    nlevel,
     int    nwno,
@@ -986,8 +988,7 @@ extern "C" void get_reflected_1d_allocate_buffers(
     ReflectedContext &ctx = g_ref_ctx;
 
     if (ctx.initialized) {
-        fprintf(stderr, "get_reflected_1d_init: already initialized, ignoring.\n");
-        return;
+        get_reflected_1d_free();
     }
 
     ctx.nlevel = nlevel;
@@ -1072,8 +1073,7 @@ extern "C" void get_reflected_1d_run(
     double        cos_theta,
     // double        surf_reflect,
     double        b_top,
-    const double *gweight,
-    const double *tweight,
+    const double *combined_weights,
     double *test_out,
     double *flux_minus_all_out,
     double *flux_plus_all_out,
@@ -1292,7 +1292,7 @@ extern "C" void get_reflected_1d_run(
         compute_disco<<<make_grid(nwno), BLOCK_SIZE>>>(
             ctx.albedo_dev,
             ctx.xint_dev,
-            gweight[i_iter], tweight[0], // if nt>1, adjust index
+            combined_weights[i_iter],
             nwno);
     }
 
@@ -1311,21 +1311,6 @@ extern "C" void get_reflected_1d_free()
     auto FREE = [](double *&p) {
         if (p) { CUDA_CHECK(cudaFree(p)); p = nullptr; }
     };
-
-    // Static inputs
-    // FREE(ctx.wno_dev);
-    // FREE(ctx.f0pi_dev);
-    // FREE(ctx.tau_dev);
-    // FREE(ctx.tau_og_dev);
-    // FREE(ctx.dtau_dev);
-    // FREE(ctx.w0_dev);
-    // FREE(ctx.cosb_dev);
-    // FREE(ctx.gcos2_dev);
-    // FREE(ctx.ftau_cld_dev);
-    // FREE(ctx.ftau_ray_dev);
-    // FREE(ctx.w0_og_dev);
-    // FREE(ctx.cosb_og_dev);
-    // FREE(ctx.dtau_og_dev);
 
     // Working arrays
     FREE(ctx.g1_dev);
@@ -1367,7 +1352,6 @@ extern "C" void get_reflected_1d_free()
     FREE(ctx.A_matrix_dev);
 
     FREE(ctx.p_single_dev);
-    // FREE(ctx.albedo_dev);
 
     FREE(ctx.xint_dev);
     FREE(ctx.xint_out_dev);
@@ -1380,10 +1364,26 @@ extern "C" void get_reflected_1d_free()
     FREE(ctx.flux_minus_midpt_dev);
     FREE(ctx.flux_plus_midpt_dev);
 
-    // FREE(ctx.flux_minus_all_dev);
-    // FREE(ctx.flux_plus_all_dev);
-    // FREE(ctx.flux_minus_midpt_all_dev);
-    // FREE(ctx.flux_plus_midpt_all_dev);
+    // Static inputs (CuPy managed, reset pointers)
+    ctx.wno_dev      = nullptr;
+    ctx.f0pi_dev     = nullptr;
+    ctx.tau_dev      = nullptr;
+    ctx.tau_og_dev   = nullptr;
+    ctx.dtau_dev     = nullptr;
+    ctx.w0_dev       = nullptr;
+    ctx.cosb_dev     = nullptr;
+    ctx.gcos2_dev    = nullptr;
+    ctx.ftau_cld_dev = nullptr;
+    ctx.ftau_ray_dev = nullptr;
+    ctx.w0_og_dev    = nullptr;
+    ctx.cosb_og_dev  = nullptr;
+    ctx.dtau_og_dev  = nullptr;
+    ctx.atm_surf_reflect_dev = nullptr;
+    ctx.albedo_dev   = nullptr;
+    ctx.flux_minus_all_dev       = nullptr;
+    ctx.flux_plus_all_dev        = nullptr;
+    ctx.flux_minus_midpt_all_dev = nullptr;
+    ctx.flux_plus_midpt_all_dev  = nullptr;
 
     ctx.initialized = false;
 }

--- a/picaso/gpu/thermal_1d_kernel.cu
+++ b/picaso/gpu/thermal_1d_kernel.cu
@@ -67,17 +67,18 @@ __global__ void setup_tri_diag_last(int nlayer,int nwno,  double *c_plus_up_dev,
                                   double *A_odd_dev, double *B_odd_dev, double *C_odd_dev, double *D_odd_dev){
 
 
-   //
-   // int blockId = blockIdx.x + blockIdx.y * gridDim.x;
-   // int index = blockId * (blockDim.x * blockDim.y) + (threadIdx.y * blockDim.x) + threadIdx.x;
-   int index = blockIdx.x * blockDim.x + threadIdx.x;
 
-   if ( (index > (nlayer-1)*nwno) && (index < nlayer*nwno) ){
+   int index_wn = blockIdx.x * blockDim.x + threadIdx.x;
 
-     A_odd_dev[index+nlayer*nwno] = e1_dev[index]-atm_surf_reflect_dev[index]*e3_dev[index];
-     B_odd_dev[index+nlayer*nwno] = e2_dev[index]-atm_surf_reflect_dev[index]*e4_dev[index];
-     C_odd_dev[index+nlayer*nwno] = 0.0;
-     D_odd_dev[index+nlayer*nwno] = b_surface_dev[index -(nlayer-1)*nwno ]-c_plus_down_dev[index] + atm_surf_reflect_dev[index]*c_minus_down_dev[index];
+   if ( index_wn < nwno ){
+     int index_layer = nlayer - 1;
+     int index = index_layer * nwno + index_wn;
+     int index_tri = (2 * nlayer - 1) * nwno + index_wn;
+
+     A_odd_dev[index_tri] = e1_dev[index]-atm_surf_reflect_dev[index_wn]*e3_dev[index];
+     B_odd_dev[index_tri] = e2_dev[index]-atm_surf_reflect_dev[index_wn]*e4_dev[index];
+     C_odd_dev[index_tri] = 0.0;
+     D_odd_dev[index_tri] = b_surface_dev[index_wn]-c_plus_down_dev[index] + atm_surf_reflect_dev[index_wn]*c_minus_down_dev[index];
 
    }
 
@@ -154,6 +155,7 @@ __global__ void calculate_blackbody(double *lvl_T_dev, double *wno_dev, double *
         } else if (calc_type == 1) {
             // Blackbody integrated calculation
             int nbb = 1; // Assuming nbb is 1; adjust as needed
+            all_b_dev[index] = 0.0;
             for (int i_iter = -nbb; i_iter < nbb + 1; i_iter++) {
                 double wavenum = wno_dev[index_wn] + i_iter * wno0_dev[index_wn] / (2.0 * nbb);
                 all_b_dev[index] += c1 * pow(wavenum, 3) / (exp(c2 * wavenum / lvl_T_dev[index_layer]) - 1.0);
@@ -306,7 +308,7 @@ __global__ void initialize_and_solve_tridiagonal(
     if (wn >= nwno) return;
 
 
-    int total_layers = 2 * (nlayer - 1);
+    int total_layers = 2 * nlayer;
     int stride = nwno;
 
     // --------------------------
@@ -780,6 +782,8 @@ extern "C" void get_thermal_1d_set_inputs(
 
 }
 
+extern "C" void get_thermal_1d_free();
+
 extern "C" void get_thermal_1d_allocate_buffers(
     int    nlevel,
     int    nwno,
@@ -789,9 +793,7 @@ extern "C" void get_thermal_1d_allocate_buffers(
     ThermalContext &ctx = g_ctx;
 
     if (ctx.initialized) {
-        // already initialized – could free and re-init, or just return
-        fprintf(stderr, "get_thermal_1d_init: already initialized, ignoring.\n");
-        return;
+        get_thermal_1d_free();
     }
 
     ctx.nlevel = nlevel;
@@ -1127,9 +1129,24 @@ extern "C" void get_thermal_1d_free()
     FREE(ctx.flux_minus_mdpt_dev);
     FREE(ctx.flux_plus_mdpt_dev);
 
+    FREE(ctx.flux_minus_all_dev);
+    FREE(ctx.flux_plus_all_dev);
+    FREE(ctx.flux_minus_mdpt_all_dev);
+    FREE(ctx.flux_plus_mdpt_all_dev);
+
 
     FREE(ctx.exptrm_angle_dev);
     FREE(ctx.exptrm_angle_mdpt_dev);
+
+    ctx.wno_dev = nullptr;
+    ctx.wno0_dev = nullptr;
+    ctx.dtau_og_dev = nullptr;
+    ctx.w0_no_raman_dev = nullptr;
+    ctx.cosb_og_dev = nullptr;
+    ctx.lvl_T_dev = nullptr;
+    ctx.lvl_P_dev = nullptr;
+    ctx.surf_reflect_dev = nullptr;
+    ctx.flux_at_top_dev = nullptr;
 
     ctx.initialized = false;
 }

--- a/picaso/gpu/thermal_1d_kernel_at_top.cu
+++ b/picaso/gpu/thermal_1d_kernel_at_top.cu
@@ -67,17 +67,18 @@ __global__ void setup_tri_diag_last(int nlayer,int nwno,  double *c_plus_up_dev,
                                   double *A_odd_dev, double *B_odd_dev, double *C_odd_dev, double *D_odd_dev){
 
 
-   //
-   // int blockId = blockIdx.x + blockIdx.y * gridDim.x;
-   // int index = blockId * (blockDim.x * blockDim.y) + (threadIdx.y * blockDim.x) + threadIdx.x;
-   int index = blockIdx.x * blockDim.x + threadIdx.x;
 
-   if ( (index > (nlayer-1)*nwno) && (index < nlayer*nwno) ){
+   int index_wn = blockIdx.x * blockDim.x + threadIdx.x;
 
-     A_odd_dev[index+nlayer*nwno] = e1_dev[index]-atm_surf_reflect_dev[index]*e3_dev[index];
-     B_odd_dev[index+nlayer*nwno] = e2_dev[index]-atm_surf_reflect_dev[index]*e4_dev[index];
-     C_odd_dev[index+nlayer*nwno] = 0.0;
-     D_odd_dev[index+nlayer*nwno] = b_surface_dev[index -(nlayer-1)*nwno ]-c_plus_down_dev[index] + atm_surf_reflect_dev[index]*c_minus_down_dev[index];
+   if ( index_wn < nwno ){
+     int index_layer = nlayer - 1;
+     int index = index_layer * nwno + index_wn;
+     int index_tri = (2 * nlayer - 1) * nwno + index_wn;
+
+     A_odd_dev[index_tri] = e1_dev[index]-atm_surf_reflect_dev[index_wn]*e3_dev[index];
+     B_odd_dev[index_tri] = e2_dev[index]-atm_surf_reflect_dev[index_wn]*e4_dev[index];
+     C_odd_dev[index_tri] = 0.0;
+     D_odd_dev[index_tri] = b_surface_dev[index_wn]-c_plus_down_dev[index] + atm_surf_reflect_dev[index_wn]*c_minus_down_dev[index];
 
    }
 
@@ -154,6 +155,7 @@ __global__ void calculate_blackbody(double *lvl_T_dev, double *wno_dev, double *
         } else if (calc_type == 1) {
             // Blackbody integrated calculation
             int nbb = 1; // Assuming nbb is 1; adjust as needed
+            all_b_dev[index] = 0.0;
             for (int i_iter = -nbb; i_iter < nbb + 1; i_iter++) {
                 double wavenum = wno_dev[index_wn] + i_iter * wno0_dev[index_wn] / (2.0 * nbb);
                 all_b_dev[index] += c1 * pow(wavenum, 3) / (exp(c2 * wavenum / lvl_T_dev[index_layer]) - 1.0);
@@ -306,7 +308,7 @@ __global__ void initialize_and_solve_tridiagonal(
     if (wn >= nwno) return;
 
 
-    int total_layers = 2 * (nlayer - 1);
+    int total_layers = 2 * nlayer;
     int stride = nwno;
 
     // --------------------------
@@ -706,6 +708,8 @@ extern "C" void get_thermal_1d_set_inputs(
 
 
 
+extern "C" void get_thermal_1d_free();
+
 extern "C" void get_thermal_1d_allocate_buffers(
     int    nlevel,
     int    nwno,
@@ -715,9 +719,7 @@ extern "C" void get_thermal_1d_allocate_buffers(
     ThermalContext &ctx = g_ctx;
 
     if (ctx.initialized) {
-        // already initialized – could free and re-init, or just return
-        fprintf(stderr, "get_thermal_1d_init: already initialized, ignoring.\n");
-        return;
+        get_thermal_1d_free();
     }
 
     ctx.nlevel = nlevel;
@@ -1039,6 +1041,16 @@ extern "C" void get_thermal_1d_free()
 
     FREE(ctx.exptrm_angle_dev);
     FREE(ctx.exptrm_angle_mdpt_dev);
+
+    ctx.wno_dev = nullptr;
+    ctx.wno0_dev = nullptr;
+    ctx.dtau_og_dev = nullptr;
+    ctx.w0_no_raman_dev = nullptr;
+    ctx.cosb_og_dev = nullptr;
+    ctx.lvl_T_dev = nullptr;
+    ctx.lvl_P_dev = nullptr;
+    ctx.surf_reflect_dev = nullptr;
+    ctx.flux_at_top_dev = nullptr;
 
     ctx.initialized = false;
 }

--- a/picaso/gpu/transit_1d_kernel.cu
+++ b/picaso/gpu/transit_1d_kernel.cu
@@ -170,6 +170,8 @@ struct TransitContext {
 
 static TransitContext g_ctx;
 
+extern "C" void get_transit_1d_free();
+
 extern "C" void get_transit_1d_allocate_buffers(
     int nlevel,
     int nwno
@@ -177,8 +179,7 @@ extern "C" void get_transit_1d_allocate_buffers(
     TransitContext& ctx = g_ctx;
 
     if (ctx.initialized) {
-        fprintf(stderr, "get_transit_1d_allocate_buffers: already initialized, ignoring.\n");
-        return;
+        get_transit_1d_free();
     }
 
     ctx.nlevel = nlevel;


### PR DESCRIPTION
This commit addresses several critical issues in the GPU implementation:
- Made all GPU buffer allocation functions re-entrant safe by calling their corresponding free functions if already initialized.
- Fixed an indexing bug in the tridiagonal solver that caused illegal memory access and incorrect results for the last layer.
- Corrected the system size in thermal solvers to 2*nlayer.
- Ensured zero-initialization of blackbody accumulation buffers.
- Fixed a host-side indexing bug in the reflected light code by pre-calculating combined weights in Python.
- Improved memory deallocation to prevent leaks and dangling pointers.

These changes eliminate 'cudaErrorIllegalAddress' and kernel crashes encountered during repeated notebook executions.