### PR TITLE
Remove option to pass in work space to new `get_reflected_1d`. 

### DIFF
--- a/picaso/fluxes_noalloc.py
+++ b/picaso/fluxes_noalloc.py
@@ -336,7 +336,6 @@ def get_reflected_1d(
     get_lvl_flux,
     toon_coefficients,
     b_top,
-    reflected=None,
 ):
     """Compute reflected-light fluxes and intensities.
 
@@ -414,9 +413,6 @@ def get_reflected_1d(
         Selects the Toon et al. coefficient set.
     b_top : float
         Diffuse radiation incident at the top of the atmosphere.
-    reflected : GetReflected1D, optional
-        Preallocated reflected-light container. If omitted, a new container is
-        created for this call.
 
     Returns
     -------
@@ -428,11 +424,8 @@ def get_reflected_1d(
         nwno)`` when level fluxes are enabled, otherwise an empty array.
     """
 
-    if reflected is None:
-        # Allocate work space.
-        reflected = GetReflected1D(nlevel - 1, nwno, numg, numt, get_lvl_flux, get_toa_intensity)
-    else:
-        reflected._ensure(nlevel - 1, nwno, numg, numt, get_lvl_flux, get_toa_intensity)
+    # Allocate work space
+    reflected = GetReflected1D(nlevel - 1, nwno, numg, numt, get_lvl_flux, get_toa_intensity)
 
     # Parallel loop over wavelength
     for w in nb.prange(nwno):


### PR DESCRIPTION
This small PR is meant to fix #420. Users with Numba versions <0.62.0 were hitting a compile error in `picaso/fluxes_noalloc.py`. Here, I simplify the code to work with older versions of Numba. The changes should only fix the compile error and have no impact on any computational result.